### PR TITLE
Fix Docker healthcheck IPv6 resolution failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,6 @@ USER nginx
 EXPOSE 80
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:80/ || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:80/ || exit 1
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - VIBRDROME_DEFAULT_SERVER=  # e.g. https://music.example.com
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:80/"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:80/"]
       interval: 30s
       timeout: 3s
       start_period: 5s


### PR DESCRIPTION
## Summary
Fix healthcheck failing on NAS Docker setups (Synology/QNAP) where `localhost` resolves to `[::1]` (IPv6) but nginx only listens on IPv4.

Changed `http://localhost:80/` to `http://127.0.0.1:80/` in both Dockerfile HEALTHCHECK and docker-compose.yml.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [x] `npm run test:run` — 120/120 pass
- [ ] Docker build + healthcheck passes on NAS

🤖 Generated with [Claude Code](https://claude.com/claude-code)