### PR TITLE
Add projectM preset store and IndexedDB cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint": "^10.3.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^17.6.0",
         "happy-dom": "^20.9.0",
         "husky": "^9.1.7",
@@ -2681,6 +2682,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint": "^10.3.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^17.6.0",
     "happy-dom": "^20.9.0",
     "husky": "^9.1.7",

--- a/src/stores/presetStore.test.ts
+++ b/src/stores/presetStore.test.ts
@@ -1,0 +1,158 @@
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import type { PresetManifest, PresetRecord } from '../types/presets';
+
+// Mock the network layer; keep the real DEFAULT_PRESETS_BASE.
+vi.mock('../utils/presetBundle', async (orig) => {
+  const actual = await orig<typeof import('../utils/presetBundle')>();
+  return { ...actual, fetchManifest: vi.fn(), fetchShard: vi.fn() };
+});
+
+import { usePresetStore } from './presetStore';
+import * as cache from '../utils/presetCache';
+import { fetchManifest, fetchShard } from '../utils/presetBundle';
+
+const MANIFEST: PresetManifest = {
+  version: 1,
+  sources: ['cream-of-the-crop'],
+  totalPresets: 3,
+  totalRawBytes: 0,
+  totalGzBytes: 0,
+  shards: [
+    { file: 'Geometric.ndjson.gz', category: 'Geometric', count: 2, rawBytes: 0, gzBytes: 0 },
+    { file: 'Fractal.ndjson.gz', category: 'Fractal', count: 1, rawBytes: 0, gzBytes: 0 },
+  ],
+  presets: [
+    { name: 'Cube', path: 'cream/Geometric/Cube.milk', category: 'Geometric', shard: 'Geometric.ndjson.gz' },
+    { name: 'Grid', path: 'cream/Geometric/Grid.milk', category: 'Geometric', shard: 'Geometric.ndjson.gz' },
+    { name: 'Julia', path: 'cream/Fractal/Julia.milk', category: 'Fractal', shard: 'Fractal.ndjson.gz' },
+  ],
+};
+
+const SHARDS: Record<string, PresetRecord[]> = {
+  'Geometric.ndjson.gz': [
+    { name: 'Cube', path: 'cream/Geometric/Cube.milk', text: 'CUBE' },
+    { name: 'Grid', path: 'cream/Geometric/Grid.milk', text: 'GRID' },
+  ],
+  'Fractal.ndjson.gz': [{ name: 'Julia', path: 'cream/Fractal/Julia.milk', text: 'JULIA' }],
+};
+
+beforeEach(async () => {
+  await cache.clearPresetCache();
+  usePresetStore.setState({
+    manifest: null,
+    categories: [],
+    loadedShards: new Set(),
+    loadingShards: new Set(),
+    loading: false,
+    error: null,
+    base: '/presets',
+  });
+  (fetchManifest as Mock).mockReset().mockResolvedValue(MANIFEST);
+  (fetchShard as Mock).mockReset().mockImplementation(async (file: string) => SHARDS[file] ?? []);
+});
+
+describe('init', () => {
+  it('loads + caches the manifest and derives categories', async () => {
+    await usePresetStore.getState().init();
+    const s = usePresetStore.getState();
+    expect(s.manifest?.totalPresets).toBe(3);
+    expect(s.categories).toEqual(['Geometric', 'Fractal']);
+    expect(s.error).toBeNull();
+    // cached for next time
+    expect((await cache.getCachedManifest())?.version).toBe(1);
+  });
+
+  it('uses the cached manifest without re-fetching', async () => {
+    await cache.cacheManifest(MANIFEST);
+    await usePresetStore.getState().init();
+    expect(fetchManifest as Mock).not.toHaveBeenCalled();
+  });
+
+  it('records an error when the fetch fails', async () => {
+    (fetchManifest as Mock).mockRejectedValue(new Error('boom'));
+    await usePresetStore.getState().init();
+    expect(usePresetStore.getState().error).toBe('boom');
+  });
+});
+
+describe('listPresets', () => {
+  beforeEach(async () => {
+    await usePresetStore.getState().init();
+  });
+  it('lists all by default', () => {
+    expect(usePresetStore.getState().listPresets()).toHaveLength(3);
+  });
+  it('filters by category', () => {
+    const geo = usePresetStore.getState().listPresets({ category: 'Geometric' });
+    expect(geo.map((p) => p.name)).toEqual(['Cube', 'Grid']);
+  });
+  it('filters by case-insensitive search', () => {
+    expect(usePresetStore.getState().listPresets({ search: 'jul' })).toHaveLength(1);
+  });
+});
+
+describe('ensureShard / lazy loading', () => {
+  beforeEach(async () => {
+    await usePresetStore.getState().init();
+  });
+
+  it('downloads + caches a shard and marks it loaded', async () => {
+    await usePresetStore.getState().ensureShard('Geometric.ndjson.gz');
+    expect(usePresetStore.getState().loadedShards.has('Geometric.ndjson.gz')).toBe(true);
+    expect((await cache.getCachedPreset('cream/Geometric/Cube.milk'))?.text).toBe('CUBE');
+    expect(await cache.isShardCached('Geometric.ndjson.gz')).toBe(true);
+  });
+
+  it('is idempotent — does not re-fetch a loaded shard', async () => {
+    await usePresetStore.getState().ensureShard('Geometric.ndjson.gz');
+    await usePresetStore.getState().ensureShard('Geometric.ndjson.gz');
+    expect((fetchShard as Mock).mock.calls.length).toBe(1);
+  });
+
+  it('does not re-fetch a shard already cached from a previous session', async () => {
+    await cache.cacheShardPresets(SHARDS['Geometric.ndjson.gz']);
+    await cache.markShardCached('Geometric.ndjson.gz');
+    await usePresetStore.getState().ensureShard('Geometric.ndjson.gz');
+    expect(fetchShard as Mock).not.toHaveBeenCalled();
+    expect(usePresetStore.getState().loadedShards.has('Geometric.ndjson.gz')).toBe(true);
+  });
+
+  it('clears the loading flag and records error on failure', async () => {
+    (fetchShard as Mock).mockRejectedValueOnce(new Error('net down'));
+    await expect(usePresetStore.getState().ensureShard('Geometric.ndjson.gz')).rejects.toThrow();
+    const s = usePresetStore.getState();
+    expect(s.loadingShards.has('Geometric.ndjson.gz')).toBe(false);
+    expect(s.error).toBe('net down');
+  });
+
+  it('ensureCategory loads the backing shard', async () => {
+    await usePresetStore.getState().ensureCategory('Fractal');
+    expect(usePresetStore.getState().loadedShards.has('Fractal.ndjson.gz')).toBe(true);
+  });
+});
+
+describe('getPresetText', () => {
+  beforeEach(async () => {
+    await usePresetStore.getState().init();
+  });
+  it('auto-loads the shard and returns the raw text', async () => {
+    const text = await usePresetStore.getState().getPresetText('cream/Fractal/Julia.milk');
+    expect(text).toBe('JULIA');
+    expect(usePresetStore.getState().loadedShards.has('Fractal.ndjson.gz')).toBe(true);
+  });
+  it('returns null for an unknown path', async () => {
+    expect(await usePresetStore.getState().getPresetText('nope')).toBeNull();
+  });
+});
+
+describe('clear', () => {
+  it('wipes cache + state', async () => {
+    await usePresetStore.getState().init();
+    await usePresetStore.getState().ensureShard('Geometric.ndjson.gz');
+    await usePresetStore.getState().clear();
+    expect(usePresetStore.getState().manifest).toBeNull();
+    expect(usePresetStore.getState().loadedShards.size).toBe(0);
+    expect(await cache.countCachedPresets()).toBe(0);
+  });
+});

--- a/src/stores/presetStore.ts
+++ b/src/stores/presetStore.ts
@@ -1,0 +1,133 @@
+// presetStore — the projectM-rs Milkdrop preset library/cache facade.
+//
+// Responsibilities (data layer only — no visualizer/WASM wiring here):
+//   - load the manifest (from IndexedDB if cached, else fetch + cache)
+//   - list/search presets and categories from the manifest (no shard download)
+//   - lazily ensure a shard/category is downloaded + cached on demand
+//   - retrieve a preset's raw .milk text by path (auto-loads its shard)
+//   - expose loading/progress/error state
+//
+// Lazy by default (per category/shard). Preloading is supported by calling
+// `ensureShard`/`ensureCategory` ahead of time (e.g. for all shards).
+
+import { create } from 'zustand';
+import type { PresetManifest, PresetIndexEntry } from '../types/presets';
+import { fetchManifest, fetchShard, DEFAULT_PRESETS_BASE } from '../utils/presetBundle';
+import * as cache from '../utils/presetCache';
+
+interface PresetState {
+  manifest: PresetManifest | null;
+  categories: string[];
+  loadedShards: Set<string>;
+  loadingShards: Set<string>;
+  loading: boolean; // manifest init in flight
+  error: string | null;
+  base: string;
+
+  /** Load the manifest (cache-first) and the set of already-cached shards. */
+  init: (base?: string) => Promise<void>;
+  /** List presets from the manifest, optionally filtered by category/search. */
+  listPresets: (opts?: { category?: string; search?: string }) => PresetIndexEntry[];
+  /** Download + cache a shard if not already present (idempotent). */
+  ensureShard: (shardFile: string) => Promise<void>;
+  /** Ensure the shard backing a category is loaded. */
+  ensureCategory: (category: string) => Promise<void>;
+  /** Get a preset's raw .milk text by path, loading its shard if needed. */
+  getPresetText: (path: string) => Promise<string | null>;
+  /** Wipe the cache and reset in-memory state. */
+  clear: () => Promise<void>;
+}
+
+export const usePresetStore = create<PresetState>((set, get) => ({
+  manifest: null,
+  categories: [],
+  loadedShards: new Set(),
+  loadingShards: new Set(),
+  loading: false,
+  error: null,
+  base: DEFAULT_PRESETS_BASE,
+
+  init: async (base = DEFAULT_PRESETS_BASE) => {
+    if (get().loading) return;
+    set({ loading: true, error: null, base });
+    try {
+      let manifest = await cache.getCachedManifest();
+      if (!manifest || manifest.version !== 1) {
+        manifest = await fetchManifest(base);
+        await cache.cacheManifest(manifest);
+      }
+      const loaded = new Set(await cache.getCachedShards());
+      set({
+        manifest,
+        categories: manifest.shards.map((s) => s.category),
+        loadedShards: loaded,
+        loading: false,
+      });
+    } catch (e) {
+      set({ loading: false, error: e instanceof Error ? e.message : String(e) });
+    }
+  },
+
+  listPresets: (opts) => {
+    const m = get().manifest;
+    if (!m) return [];
+    let list = m.presets;
+    if (opts?.category) list = list.filter((p) => p.category === opts.category);
+    if (opts?.search) {
+      const q = opts.search.toLowerCase();
+      list = list.filter((p) => p.name.toLowerCase().includes(q));
+    }
+    return list;
+  },
+
+  ensureShard: async (shardFile) => {
+    const { loadedShards, loadingShards, base } = get();
+    if (loadedShards.has(shardFile) || loadingShards.has(shardFile)) return;
+
+    // Already in IndexedDB from a previous session?
+    if (await cache.isShardCached(shardFile)) {
+      set((s) => ({ loadedShards: new Set(s.loadedShards).add(shardFile) }));
+      return;
+    }
+
+    set((s) => ({ loadingShards: new Set(s.loadingShards).add(shardFile) }));
+    try {
+      const records = await fetchShard(shardFile, base);
+      await cache.cacheShardPresets(records);
+      await cache.markShardCached(shardFile);
+      set((s) => {
+        const loaded = new Set(s.loadedShards).add(shardFile);
+        const loading = new Set(s.loadingShards);
+        loading.delete(shardFile);
+        return { loadedShards: loaded, loadingShards: loading };
+      });
+    } catch (e) {
+      set((s) => {
+        const loading = new Set(s.loadingShards);
+        loading.delete(shardFile);
+        return { loadingShards: loading, error: e instanceof Error ? e.message : String(e) };
+      });
+      throw e;
+    }
+  },
+
+  ensureCategory: async (category) => {
+    const m = get().manifest;
+    if (!m) return;
+    const shard = m.shards.find((s) => s.category === category);
+    if (shard) await get().ensureShard(shard.file);
+  },
+
+  getPresetText: async (path) => {
+    const m = get().manifest;
+    const entry = m?.presets.find((p) => p.path === path);
+    if (entry) await get().ensureShard(entry.shard);
+    const rec = await cache.getCachedPreset(path);
+    return rec?.text ?? null;
+  },
+
+  clear: async () => {
+    await cache.clearPresetCache();
+    set({ manifest: null, categories: [], loadedShards: new Set(), loadingShards: new Set() });
+  },
+}));

--- a/src/types/presets.ts
+++ b/src/types/presets.ts
@@ -1,0 +1,38 @@
+// Types for the projectM-rs Milkdrop preset bundles produced by the
+// `tools/preset-pack` pipeline (manifest version 1). See that tool's README.
+
+/** One gzipped NDJSON shard = all presets in one top-level category. */
+export interface ShardInfo {
+  file: string; // e.g. "Geometric.ndjson.gz"
+  category: string; // human label, e.g. "Geometric" or "! Transition"
+  count: number;
+  rawBytes: number;
+  gzBytes: number;
+}
+
+/** Flat per-preset index entry (in the manifest) for listing/search without
+ *  downloading any shard. */
+export interface PresetIndexEntry {
+  name: string; // display name (filename sans extension)
+  path: string; // stable unique key: "<pack>/<relpath>.milk"
+  category: string;
+  shard: string; // shard file that holds the full text
+}
+
+/** `manifest.json` — the index of the whole corpus. */
+export interface PresetManifest {
+  version: number; // 1
+  sources: string[];
+  totalPresets: number;
+  totalRawBytes: number;
+  totalGzBytes: number;
+  shards: ShardInfo[];
+  presets: PresetIndexEntry[];
+}
+
+/** One preset record as stored in a shard / IndexedDB (keyed by `path`). */
+export interface PresetRecord {
+  name: string;
+  path: string; // primary key
+  text: string; // raw .milk source — fed straight to PmEngine.load_preset
+}

--- a/src/utils/presetBundle.test.ts
+++ b/src/utils/presetBundle.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseManifest,
+  parseNdjson,
+  decodeShardBytes,
+  fetchManifest,
+  fetchShard,
+} from './presetBundle';
+import type { PresetManifest } from '../types/presets';
+
+// gzip a string using the web CompressionStream API (no Node types needed).
+async function gzip(text: string): Promise<Uint8Array> {
+  const cs = new CompressionStream('gzip');
+  const writer = cs.writable.getWriter();
+  void writer.write(new TextEncoder().encode(text));
+  void writer.close();
+  return new Uint8Array(await new Response(cs.readable).arrayBuffer());
+}
+
+const MANIFEST: PresetManifest = {
+  version: 1,
+  sources: ['cream-of-the-crop'],
+  totalPresets: 2,
+  totalRawBytes: 100,
+  totalGzBytes: 50,
+  shards: [{ file: 'Geometric.ndjson.gz', category: 'Geometric', count: 2, rawBytes: 100, gzBytes: 50 }],
+  presets: [
+    { name: 'A', path: 'cream/Geometric/A.milk', category: 'Geometric', shard: 'Geometric.ndjson.gz' },
+    { name: 'B', path: 'cream/Geometric/B.milk', category: 'Geometric', shard: 'Geometric.ndjson.gz' },
+  ],
+};
+
+const NDJSON =
+  JSON.stringify({ name: 'A', path: 'cream/Geometric/A.milk', text: '[preset00]\nA' }) +
+  '\n' +
+  JSON.stringify({ name: 'B', path: 'cream/Geometric/B.milk', text: '[preset00]\nB' }) +
+  '\n';
+
+const mockFetch = (body: { json?: unknown; bytes?: Uint8Array; ok?: boolean; status?: number }) =>
+  (async () =>
+    ({
+      ok: body.ok ?? true,
+      status: body.status ?? 200,
+      json: async () => body.json,
+      arrayBuffer: async () => (body.bytes ? body.bytes.buffer : new ArrayBuffer(0)),
+    }) as Response) as unknown as typeof fetch;
+
+describe('parseManifest', () => {
+  it('accepts a valid v1 manifest', () => {
+    expect(parseManifest(MANIFEST).totalPresets).toBe(2);
+  });
+  it('rejects wrong version / shape', () => {
+    expect(() => parseManifest({ ...MANIFEST, version: 2 })).toThrow();
+    expect(() => parseManifest({ version: 1 })).toThrow();
+    expect(() => parseManifest(null)).toThrow();
+  });
+});
+
+describe('parseNdjson', () => {
+  it('parses well-formed lines', () => {
+    const recs = parseNdjson(NDJSON);
+    expect(recs).toHaveLength(2);
+    expect(recs[0]).toMatchObject({ name: 'A', path: 'cream/Geometric/A.milk' });
+    expect(recs[1].text).toContain('B');
+  });
+  it('skips malformed / incomplete lines without throwing', () => {
+    const messy =
+      'not json\n' +
+      JSON.stringify({ path: 'x', text: 'ok' }) +
+      '\n' +
+      JSON.stringify({ path: 'no-text' }) + // missing text → skipped
+      '\n\n';
+    const recs = parseNdjson(messy);
+    expect(recs).toHaveLength(1);
+    expect(recs[0].path).toBe('x');
+  });
+});
+
+describe('decodeShardBytes', () => {
+  it('decompresses gzipped NDJSON', async () => {
+    const gz = await gzip(NDJSON);
+    const text = await decodeShardBytes(gz.buffer as ArrayBuffer);
+    expect(text).toBe(NDJSON);
+  });
+  it('passes through already-decoded (non-gzip) bytes', async () => {
+    const plain = new TextEncoder().encode(NDJSON);
+    const text = await decodeShardBytes(plain.buffer);
+    expect(text).toBe(NDJSON);
+  });
+});
+
+describe('fetchManifest', () => {
+  it('fetches and validates', async () => {
+    const m = await fetchManifest('/presets', mockFetch({ json: MANIFEST }));
+    expect(m.shards[0].category).toBe('Geometric');
+  });
+  it('throws on non-ok response', async () => {
+    await expect(fetchManifest('/presets', mockFetch({ ok: false, status: 404 }))).rejects.toThrow();
+  });
+});
+
+describe('fetchShard', () => {
+  it('fetches, gzip-decodes, and parses', async () => {
+    const gz = await gzip(NDJSON);
+    const recs = await fetchShard(
+      'Geometric.ndjson.gz',
+      '/presets',
+      mockFetch({ bytes: gz }),
+    );
+    expect(recs).toHaveLength(2);
+    expect(recs.map((r) => r.name)).toEqual(['A', 'B']);
+  });
+  it('throws on non-ok response', async () => {
+    await expect(
+      fetchShard('Geometric.ndjson.gz', '/presets', mockFetch({ ok: false, status: 500 })),
+    ).rejects.toThrow();
+  });
+});

--- a/src/utils/presetBundle.ts
+++ b/src/utils/presetBundle.ts
@@ -1,0 +1,87 @@
+// Network + decode layer for the projectM-rs preset bundles.
+//
+// Bundles are produced by `tools/preset-pack` (manifest v1): a manifest.json
+// index plus one gzipped NDJSON shard per category. These helpers fetch and
+// decode them. They are intentionally side-effect-free (caching lives in
+// presetCache.ts) and take an injectable `fetchFn` so they're easy to test.
+
+import type { PresetManifest, PresetRecord } from '../types/presets';
+
+/** Where the bundles are served from (copied into public/presets/ later). */
+export const DEFAULT_PRESETS_BASE = '/presets';
+
+type FetchFn = typeof fetch;
+
+/** Validate and narrow an untrusted JSON value to a v1 manifest. */
+export function parseManifest(json: unknown): PresetManifest {
+  const m = json as PresetManifest;
+  if (
+    !m ||
+    typeof m !== 'object' ||
+    m.version !== 1 ||
+    !Array.isArray(m.shards) ||
+    !Array.isArray(m.presets)
+  ) {
+    throw new Error('invalid preset manifest (expected version 1 with shards[]/presets[])');
+  }
+  return m;
+}
+
+export async function fetchManifest(
+  base: string = DEFAULT_PRESETS_BASE,
+  fetchFn: FetchFn = fetch,
+): Promise<PresetManifest> {
+  const res = await fetchFn(`${base}/manifest.json`);
+  if (!res.ok) throw new Error(`manifest fetch failed: ${res.status}`);
+  return parseManifest(await res.json());
+}
+
+/** Parse NDJSON shard text into preset records, skipping malformed lines. */
+export function parseNdjson(text: string): PresetRecord[] {
+  const out: PresetRecord[] = [];
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const rec = JSON.parse(line) as PresetRecord;
+      if (rec && typeof rec.path === 'string' && typeof rec.text === 'string') {
+        out.push({ name: String(rec.name ?? rec.path), path: rec.path, text: rec.text });
+      }
+    } catch {
+      // Skip a corrupt line rather than failing the whole shard.
+    }
+  }
+  return out;
+}
+
+/**
+ * Decode a shard body to text. The shards are pre-gzipped `.ndjson.gz` that we
+ * decompress in JS via `DecompressionStream('gzip')`.
+ *
+ * Content-Encoding gotcha: if the host *also* applied `Content-Encoding: gzip`,
+ * the browser already decoded the body, so the bytes we receive are plain
+ * NDJSON (no gzip magic). We detect the gzip magic number (0x1f 0x8b) and only
+ * decompress when it's actually present — otherwise treat the bytes as UTF-8.
+ */
+export async function decodeShardBytes(buf: ArrayBuffer): Promise<string> {
+  const bytes = new Uint8Array(buf);
+  const isGzip = bytes.length >= 2 && bytes[0] === 0x1f && bytes[1] === 0x8b;
+  if (!isGzip) {
+    return new TextDecoder().decode(bytes);
+  }
+  const ds = new DecompressionStream('gzip');
+  const writer = ds.writable.getWriter();
+  void writer.write(bytes);
+  void writer.close();
+  return new Response(ds.readable).text();
+}
+
+export async function fetchShard(
+  shardFile: string,
+  base: string = DEFAULT_PRESETS_BASE,
+  fetchFn: FetchFn = fetch,
+): Promise<PresetRecord[]> {
+  const res = await fetchFn(`${base}/${shardFile}`);
+  if (!res.ok) throw new Error(`shard fetch failed (${shardFile}): ${res.status}`);
+  const text = await decodeShardBytes(await res.arrayBuffer());
+  return parseNdjson(text);
+}

--- a/src/utils/presetCache.test.ts
+++ b/src/utils/presetCache.test.ts
@@ -1,0 +1,81 @@
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import * as cache from './presetCache';
+import type { PresetManifest, PresetRecord } from '../types/presets';
+
+const MANIFEST: PresetManifest = {
+  version: 1,
+  sources: ['cream-of-the-crop'],
+  totalPresets: 1,
+  totalRawBytes: 10,
+  totalGzBytes: 5,
+  shards: [{ file: 'Geometric.ndjson.gz', category: 'Geometric', count: 1, rawBytes: 10, gzBytes: 5 }],
+  presets: [{ name: 'A', path: 'cream/A.milk', category: 'Geometric', shard: 'Geometric.ndjson.gz' }],
+};
+
+const rec = (path: string, text: string): PresetRecord => ({ name: path, path, text });
+
+beforeEach(async () => {
+  await cache.clearPresetCache();
+});
+
+describe('manifest cache', () => {
+  it('round-trips the manifest', async () => {
+    expect(await cache.getCachedManifest()).toBeNull();
+    await cache.cacheManifest(MANIFEST);
+    const got = await cache.getCachedManifest();
+    expect(got?.version).toBe(1);
+    expect(got?.totalPresets).toBe(1);
+  });
+});
+
+describe('preset records', () => {
+  it('stores and retrieves by path', async () => {
+    await cache.cacheShardPresets([rec('cream/A.milk', 'AAA'), rec('cream/B.milk', 'BBB')]);
+    expect((await cache.getCachedPreset('cream/A.milk'))?.text).toBe('AAA');
+    expect((await cache.getCachedPreset('cream/B.milk'))?.text).toBe('BBB');
+    expect(await cache.countCachedPresets()).toBe(2);
+  });
+
+  it('returns null for an unknown path', async () => {
+    expect(await cache.getCachedPreset('nope')).toBeNull();
+  });
+
+  it('dedupes by path (re-store overwrites, count unchanged)', async () => {
+    await cache.cacheShardPresets([rec('cream/A.milk', 'v1')]);
+    await cache.cacheShardPresets([rec('cream/A.milk', 'v2')]);
+    expect((await cache.getCachedPreset('cream/A.milk'))?.text).toBe('v2');
+    expect(await cache.countCachedPresets()).toBe(1);
+  });
+});
+
+describe('loaded-shard bookkeeping', () => {
+  it('marks and lists cached shards without duplicates', async () => {
+    expect(await cache.getCachedShards()).toEqual([]);
+    expect(await cache.isShardCached('Geometric.ndjson.gz')).toBe(false);
+
+    await cache.markShardCached('Geometric.ndjson.gz');
+    await cache.markShardCached('Geometric.ndjson.gz'); // dup ignored
+    await cache.markShardCached('Fractal.ndjson.gz');
+
+    expect(await cache.isShardCached('Geometric.ndjson.gz')).toBe(true);
+    expect((await cache.getCachedShards()).sort()).toEqual([
+      'Fractal.ndjson.gz',
+      'Geometric.ndjson.gz',
+    ]);
+  });
+});
+
+describe('clearPresetCache', () => {
+  it('empties presets and meta', async () => {
+    await cache.cacheManifest(MANIFEST);
+    await cache.cacheShardPresets([rec('cream/A.milk', 'AAA')]);
+    await cache.markShardCached('Geometric.ndjson.gz');
+
+    await cache.clearPresetCache();
+
+    expect(await cache.getCachedManifest()).toBeNull();
+    expect(await cache.countCachedPresets()).toBe(0);
+    expect(await cache.getCachedShards()).toEqual([]);
+  });
+});

--- a/src/utils/presetCache.ts
+++ b/src/utils/presetCache.ts
@@ -1,0 +1,118 @@
+// IndexedDB persistence for projectM-rs presets, mirroring the app's existing
+// idb pattern (see downloadStore.ts / lastfmCache.ts). Two object stores:
+//   - `presets`: full preset records keyed by `path` (so re-storing a path
+//                dedupes/overwrites).
+//   - `meta`:    the cached manifest and the set of shards already downloaded,
+//                under fixed string keys.
+//
+// All reads fail soft (return null/[]); writes that matter (caching presets)
+// surface errors so the store can report them.
+
+import { openDB } from 'idb';
+import type { PresetManifest, PresetRecord } from '../types/presets';
+
+const DB_NAME = 'vibrdrome_presets';
+const DB_VERSION = 1;
+const PRESETS_STORE = 'presets';
+const META_STORE = 'meta';
+const MANIFEST_KEY = 'manifest';
+const LOADED_SHARDS_KEY = 'loadedShards';
+
+function getDB() {
+  return openDB(DB_NAME, DB_VERSION, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(PRESETS_STORE)) {
+        db.createObjectStore(PRESETS_STORE, { keyPath: 'path' });
+      }
+      if (!db.objectStoreNames.contains(META_STORE)) {
+        db.createObjectStore(META_STORE);
+      }
+    },
+  });
+}
+
+// --- manifest ---
+
+export async function cacheManifest(manifest: PresetManifest): Promise<void> {
+  try {
+    const db = await getDB();
+    await db.put(META_STORE, manifest, MANIFEST_KEY);
+  } catch {
+    /* non-fatal: a missing cached manifest just means we re-fetch */
+  }
+}
+
+export async function getCachedManifest(): Promise<PresetManifest | null> {
+  try {
+    const db = await getDB();
+    return ((await db.get(META_STORE, MANIFEST_KEY)) as PresetManifest | undefined) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// --- preset records ---
+
+/** Bulk-store preset records. Keyed by `path`, so duplicates overwrite. */
+export async function cacheShardPresets(records: PresetRecord[]): Promise<void> {
+  const db = await getDB();
+  const tx = db.transaction(PRESETS_STORE, 'readwrite');
+  await Promise.all(records.map((r) => tx.store.put(r)));
+  await tx.done;
+}
+
+export async function getCachedPreset(path: string): Promise<PresetRecord | null> {
+  try {
+    const db = await getDB();
+    return ((await db.get(PRESETS_STORE, path)) as PresetRecord | undefined) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function countCachedPresets(): Promise<number> {
+  try {
+    const db = await getDB();
+    return await db.count(PRESETS_STORE);
+  } catch {
+    return 0;
+  }
+}
+
+// --- loaded-shard bookkeeping ---
+
+export async function getCachedShards(): Promise<string[]> {
+  try {
+    const db = await getDB();
+    return ((await db.get(META_STORE, LOADED_SHARDS_KEY)) as string[] | undefined) ?? [];
+  } catch {
+    return [];
+  }
+}
+
+export async function markShardCached(file: string): Promise<void> {
+  try {
+    const db = await getDB();
+    const existing = ((await db.get(META_STORE, LOADED_SHARDS_KEY)) as string[] | undefined) ?? [];
+    if (!existing.includes(file)) {
+      existing.push(file);
+      await db.put(META_STORE, existing, LOADED_SHARDS_KEY);
+    }
+  } catch {
+    /* non-fatal */
+  }
+}
+
+export async function isShardCached(file: string): Promise<boolean> {
+  return (await getCachedShards()).includes(file);
+}
+
+export async function clearPresetCache(): Promise<void> {
+  try {
+    const db = await getDB();
+    await db.clear(PRESETS_STORE);
+    await db.clear(META_STORE);
+  } catch {
+    /* non-fatal */
+  }
+}


### PR DESCRIPTION
## What changed
Data layer only — no visualizer or WASM wiring.
- `src/types/presets.ts` — manifest v1 + record types.
- `src/utils/presetBundle.ts` — fetch manifest, fetch + `DecompressionStream` gzip-decode + safe NDJSON parse (detects gzip magic so it works regardless of `Content-Encoding`). Injectable `fetch`.
- `src/utils/presetCache.ts` — IndexedDB store `vibrdrome_presets` (presets keyed by `path` → dedupe; meta holds manifest + loaded-shard set), mirroring the app's `downloadStore`/`lastfmCache` patterns.
- `src/stores/presetStore.ts` — Zustand facade: cache-first manifest load, list/search from manifest, lazy per-shard/category download+cache, `getPresetText(path)`.
- Adds `fake-indexeddb` (devDependency, tests only).

## Verification
- `npm run lint` ✓ clean
- `npm run test:run` ✓ 163 pass / 16 files (30 new: manifest/NDJSON/gzip/cache put-get/dedupe/error)
- `npm run build` ✓

## Manual testing
N/A for this PR (pure data layer; exercised by the new unit tests). Manual end-to-end validated in the integration PR.

## Dependency / base note
**Stacked PR — base: `develop`.** First in the stack; PR 4–6 build on this. Merge this first.

## Deferred (later PRs / not in scope)
Transitions/crossfade, screenshots, and async black-frame detection are deferred. None are implemented here.