### PR TITLE
Add Milkdrop visualizer controls and settings

### DIFF
--- a/src/components/common/ShortcutsOverlay.tsx
+++ b/src/components/common/ShortcutsOverlay.tsx
@@ -33,6 +33,18 @@ const SHORTCUT_GROUPS = [
       { key: 'Ctrl + K', description: 'Command palette' },
     ],
   },
+  {
+    label: 'Visualizer',
+    shortcuts: [
+      { key: 'N', description: 'Next preset' },
+      { key: 'P', description: 'Previous preset' },
+      { key: 'A', description: 'Toggle auto-advance' },
+      { key: '[ / ]', description: 'Auto-advance interval − / +' },
+      { key: 'K', description: 'Freeze / unfreeze' },
+      { key: '.', description: 'Step one frame (while frozen)' },
+      { key: 'F', description: 'Toggle FPS overlay' },
+    ],
+  },
 ];
 
 interface ShortcutsOverlayProps {

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -15,6 +15,12 @@ export default function SettingsScreen() {
   const { accentColor, setAccentColor, lastfmApiKey, setLastfmApiKey, reduceMotion, setReduceMotion, keyboardShortcutsEnabled, setKeyboardShortcutsEnabled, streamQuality, setStreamQuality } = useUIStore();
   const { crossfadeEnabled, crossfadeDuration, setCrossfade, setCrossfadeDuration, gaplessEnabled, setGapless } = usePlayerStore();
   const { sleepFadeDuration, setSleepFadeDuration, notificationsEnabled, setNotificationsEnabled, replayGainMode, setReplayGainMode, queueSyncEnabled, setQueueSyncEnabled } = useUIStore();
+  const {
+    visualizerForceButterchurn, setVisualizerForceButterchurn,
+    visualizerAutoAdvance, setVisualizerAutoAdvance,
+    visualizerAutoAdvanceInterval, setVisualizerAutoAdvanceInterval,
+    visualizerShuffle, setVisualizerShuffle,
+  } = useUIStore();
   const eqEnabled = useEQStore((s) => s.enabled);
 
   const activeServer = servers.find((s) => s.id === activeServerId);
@@ -267,6 +273,98 @@ export default function SettingsScreen() {
                     <span
                       className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
                         keyboardShortcutsEnabled ? 'translate-x-5' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {/* Visualizer */}
+          <section>
+            <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-text-muted">
+              Visualizer
+            </h2>
+            <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
+              {/* Force Butterchurn */}
+              <div className="flex items-center justify-between">
+                <div>
+                  <span className="text-sm text-text-primary">Force Butterchurn engine</span>
+                  <p className="text-xs text-text-muted">Use the WebGL fallback even when WebGPU (projectM) is available</p>
+                </div>
+                <button
+                  role="switch"
+                  aria-checked={visualizerForceButterchurn}
+                  onClick={() => setVisualizerForceButterchurn(!visualizerForceButterchurn)}
+                  className={`relative h-6 w-11 rounded-full transition-colors ${
+                    visualizerForceButterchurn ? 'bg-accent' : 'bg-bg-tertiary'
+                  }`}
+                >
+                  <span
+                    className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                      visualizerForceButterchurn ? 'translate-x-5' : 'translate-x-0'
+                    }`}
+                  />
+                </button>
+              </div>
+
+              {/* Auto-advance + interval */}
+              <div className="border-t border-border pt-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <span className="text-sm text-text-primary">Auto-advance presets</span>
+                    <p className="text-xs text-text-muted">Cycle to the next preset automatically</p>
+                  </div>
+                  <button
+                    role="switch"
+                    aria-checked={visualizerAutoAdvance}
+                    onClick={() => setVisualizerAutoAdvance(!visualizerAutoAdvance)}
+                    className={`relative h-6 w-11 rounded-full transition-colors ${
+                      visualizerAutoAdvance ? 'bg-accent' : 'bg-bg-tertiary'
+                    }`}
+                  >
+                    <span
+                      className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                        visualizerAutoAdvance ? 'translate-x-5' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
+                {visualizerAutoAdvance && (
+                  <div className="mt-2 flex items-center gap-3">
+                    <span className="text-xs text-text-muted">Interval:</span>
+                    <select
+                      value={visualizerAutoAdvanceInterval}
+                      onChange={(e) => setVisualizerAutoAdvanceInterval(Number(e.target.value))}
+                      className="rounded border border-border bg-bg-tertiary px-2 py-1 text-xs text-text-primary outline-none"
+                    >
+                      {[5, 10, 15, 20, 30, 60].map((s) => (
+                        <option key={s} value={s}>{s}s</option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+              </div>
+
+              {/* Shuffle */}
+              <div className="border-t border-border pt-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <span className="text-sm text-text-primary">Shuffle presets</span>
+                    <p className="text-xs text-text-muted">Pick a random preset on advance instead of the next one</p>
+                  </div>
+                  <button
+                    role="switch"
+                    aria-checked={visualizerShuffle}
+                    onClick={() => setVisualizerShuffle(!visualizerShuffle)}
+                    className={`relative h-6 w-11 rounded-full transition-colors ${
+                      visualizerShuffle ? 'bg-accent' : 'bg-bg-tertiary'
+                    }`}
+                  >
+                    <span
+                      className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                        visualizerShuffle ? 'translate-x-5' : 'translate-x-0'
                       }`}
                     />
                   </button>

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -198,7 +198,28 @@ export default function VisualizerScreen() {
   const pmFrameRef = useRef<number>(0);
   const projectmEntriesRef = useRef<PresetIndexEntry[]>([]);
 
+  // Freeze/step + FPS, read by the (closure-captured) render loops via refs.
+  const frozenRef = useRef(false);
+  const stepRef = useRef(0);
+  const clockRef = useRef(0); // projectM time in seconds (held while frozen)
+  const lastTickRef = useRef(0);
+  const frameCountRef = useRef(0);
+  const fpsLastRef = useRef(0);
+  const showFpsRef = useRef(false);
+
+  // Visualizer settings (persisted) + the keyboard-shortcuts master toggle.
+  const {
+    visualizerForceButterchurn,
+    visualizerAutoAdvance, setVisualizerAutoAdvance,
+    visualizerAutoAdvanceInterval, setVisualizerAutoAdvanceInterval,
+    visualizerShuffle, setVisualizerShuffle,
+    keyboardShortcutsEnabled,
+  } = useUIStore();
+
   const [mode, setMode] = useState<'shader' | 'milkdrop'>('shader');
+  const [frozen, setFrozen] = useState(false);
+  const [showFps, setShowFps] = useState(false);
+  const [fps, setFps] = useState(0);
   const [presetIndex, setPresetIndex] = useState(0);
   const [milkdropPresetIndex, setMilkdropPresetIndex] = useState(0);
   const [milkdropPresetNames, setMilkdropPresetNames] = useState<string[]>([]);
@@ -217,6 +238,26 @@ export default function VisualizerScreen() {
     if (overlayTimeoutRef.current) clearTimeout(overlayTimeoutRef.current);
     overlayTimeoutRef.current = setTimeout(() => setShowOverlay(false), 4000);
   }, []);
+
+  // Keep loop-read refs in sync with state.
+  useEffect(() => { frozenRef.current = frozen; }, [frozen]);
+  useEffect(() => { showFpsRef.current = showFps; }, [showFps]);
+
+  // Shared FPS counter, called once per rendered frame by the active loop.
+  const tickFps = useCallback(() => {
+    frameCountRef.current++;
+    const now = performance.now();
+    if (now - fpsLastRef.current >= 500) {
+      const value = (frameCountRef.current * 1000) / (now - fpsLastRef.current);
+      frameCountRef.current = 0;
+      fpsLastRef.current = now;
+      if (showFpsRef.current) setFps(Math.round(value));
+    }
+  }, []);
+
+  const toggleFreeze = useCallback(() => { setFrozen((f) => !f); resetOverlayTimer(); }, [resetOverlayTimer]);
+  const stepFrame = useCallback(() => { stepRef.current += 1; resetOverlayTimer(); }, [resetOverlayTimer]);
+  const toggleFps = useCallback(() => { setShowFps((s) => !s); resetOverlayTimer(); }, [resetOverlayTimer]);
 
   // Set start time on mount
   useEffect(() => {
@@ -344,9 +385,10 @@ export default function VisualizerScreen() {
     }
     const hasWebGPU = typeof navigator !== 'undefined' && 'gpu' in navigator;
     setMilkdropPresetIndex(0);
-    setMilkdropEngine(hasWebGPU ? 'projectm' : 'butterchurn');
+    setFrozen(false);
+    setMilkdropEngine(hasWebGPU && !visualizerForceButterchurn ? 'projectm' : 'butterchurn');
     /* eslint-enable react-hooks/set-state-in-effect */
-  }, [mode]);
+  }, [mode, visualizerForceButterchurn]);
 
   // Initialize Butterchurn when it's the chosen Milkdrop engine (fallback).
   useEffect(() => {
@@ -434,7 +476,16 @@ export default function VisualizerScreen() {
             }
           }
 
-          visualizer.render();
+          // Freeze skips render() so the last frame holds; a step renders once.
+          let doRender = true;
+          if (frozenRef.current) {
+            if (stepRef.current > 0) stepRef.current -= 1;
+            else doRender = false;
+          }
+          if (doRender) {
+            visualizer.render();
+            tickFps();
+          }
           milkdropFrameRef.current = requestAnimationFrame(renderMilkdrop);
         };
 
@@ -508,8 +559,11 @@ export default function VisualizerScreen() {
       if (!cancelled) setMilkdropReady(true);
 
       // Render loop — React owns rAF; feed the app's real playback audio.
+      // Freeze holds the clock (and skips rendering so the last frame stays);
+      // a single step advances exactly one 1/60s frame while frozen.
       let audioBuf: Float32Array<ArrayBuffer> | null = null;
-      const t0 = performance.now();
+      clockRef.current = 0;
+      lastTickRef.current = 0;
       const loop = (tMs: number) => {
         if (cancelled) return;
         const c = projectmCanvasRef.current;
@@ -522,15 +576,34 @@ export default function VisualizerScreen() {
             engine.resize(w, h);
           }
         }
-        const analyser = getPlaybackManager().getAnalyser();
-        if (analyser) {
-          if (!audioBuf || audioBuf.length !== analyser.fftSize) {
-            audioBuf = new Float32Array(analyser.fftSize);
+
+        const dt = lastTickRef.current ? Math.min((tMs - lastTickRef.current) / 1000, 0.1) : 1 / 60;
+        lastTickRef.current = tMs;
+
+        let doRender = true;
+        if (frozenRef.current) {
+          if (stepRef.current > 0) {
+            clockRef.current += 1 / 60;
+            stepRef.current -= 1;
+          } else {
+            doRender = false;
           }
-          analyser.getFloatTimeDomainData(audioBuf);
-          engine.push_audio(audioBuf);
+        } else {
+          clockRef.current += dt;
         }
-        engine.render((tMs - t0) / 1000);
+
+        if (doRender) {
+          const analyser = getPlaybackManager().getAnalyser();
+          if (analyser) {
+            if (!audioBuf || audioBuf.length !== analyser.fftSize) {
+              audioBuf = new Float32Array(analyser.fftSize);
+            }
+            analyser.getFloatTimeDomainData(audioBuf);
+            engine.push_audio(audioBuf);
+          }
+          engine.render(clockRef.current);
+          tickFps();
+        }
         pmFrameRef.current = requestAnimationFrame(loop);
       };
       pmFrameRef.current = requestAnimationFrame(loop);
@@ -552,7 +625,7 @@ export default function VisualizerScreen() {
       projectmEntriesRef.current = [];
       setMilkdropReady(false);
     };
-  }, [mode, milkdropEngine]);
+  }, [mode, milkdropEngine, tickFps]);
 
   // Update milkdrop preset when index changes (butterchurn).
   useEffect(() => {
@@ -626,6 +699,47 @@ export default function VisualizerScreen() {
     resetOverlayTimer();
   };
 
+  // Auto-advance: cycle presets on the configured interval while in Milkdrop.
+  useEffect(() => {
+    if (mode !== 'milkdrop' || !milkdropReady || !visualizerAutoAdvance) return;
+    const ms = Math.max(1, visualizerAutoAdvanceInterval) * 1000;
+    const id = setInterval(() => {
+      if (visualizerShuffle) randomPreset();
+      else nextPreset();
+    }, ms);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, milkdropReady, visualizerAutoAdvance, visualizerAutoAdvanceInterval, visualizerShuffle]);
+
+  // Visualizer-scoped keyboard controls. A no-deps effect keeps the latest
+  // logic in a ref so the document listener (added once) always sees current
+  // state without re-subscribing every render. Mirrors the app's conventions:
+  // honors the master shortcuts toggle and ignores typing in form fields.
+  const keyHandlerRef = useRef<(e: KeyboardEvent) => void>(() => {});
+  useEffect(() => {
+    keyHandlerRef.current = (e: KeyboardEvent) => {
+      if (!keyboardShortcutsEnabled) return;
+      const tag = (e.target as HTMLElement | null)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      switch (e.key) {
+        case 'n': case 'N': nextPreset(); break;
+        case 'p': case 'P': prevPreset(); break;
+        case 'a': case 'A': setVisualizerAutoAdvance(!visualizerAutoAdvance); resetOverlayTimer(); break;
+        case '[': setVisualizerAutoAdvanceInterval(Math.max(5, visualizerAutoAdvanceInterval - 5)); resetOverlayTimer(); break;
+        case ']': setVisualizerAutoAdvanceInterval(Math.min(60, visualizerAutoAdvanceInterval + 5)); resetOverlayTimer(); break;
+        case 'k': case 'K': toggleFreeze(); break;
+        case '.': stepFrame(); break;
+        case 'f': case 'F': toggleFps(); break;
+        default: break;
+      }
+    };
+  });
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => keyHandlerRef.current(e);
+    document.addEventListener('keydown', h);
+    return () => document.removeEventListener('keydown', h);
+  }, []);
+
   const handleCanvasClick = () => {
     resetOverlayTimer();
   };
@@ -637,6 +751,14 @@ export default function VisualizerScreen() {
   const displayPresetName = mode === 'shader'
     ? currentPreset.name
     : (milkdropPresetNames[milkdropPresetIndex] || 'Loading...');
+  const hudInfo = mode === 'milkdrop' && milkdropEngine
+    ? `${milkdropEngine === 'projectm' ? 'projectM' : 'butterchurn'} · ${milkdropPresetIndex + 1}/${totalPresets || '…'}`
+    : null;
+
+  const ctrlBtn = (on: boolean, disabled = false) =>
+    `rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+      on ? 'bg-accent text-white' : 'bg-white/10 text-white/80 hover:bg-white/20'
+    } ${disabled ? 'opacity-40' : ''}`;
 
   return (
     <div
@@ -705,10 +827,17 @@ export default function VisualizerScreen() {
             </svg>
           </button>
 
-          {/* Preset name */}
-          <span className="max-w-[50%] truncate text-sm font-medium text-white/80">
-            {displayPresetName}
-          </span>
+          {/* Preset name + HUD info (engine · index/total · status) */}
+          <div className="flex max-w-[55%] flex-col items-center">
+            <span className="truncate text-sm font-medium text-white/80">
+              {displayPresetName}
+            </span>
+            {hudInfo && (
+              <span className="mt-0.5 text-[10px] font-medium tracking-wide text-white/40">
+                {hudInfo}{visualizerAutoAdvance ? ' · AUTO' : ''}{visualizerShuffle ? ' · SHUF' : ''}{frozen ? ' · FROZEN' : ''}
+              </span>
+            )}
+          </div>
 
           {/* Mode toggle */}
           <button
@@ -752,7 +881,35 @@ export default function VisualizerScreen() {
             </button>
           </>
         )}
+
+        {/* Milkdrop control bar */}
+        {mode === 'milkdrop' && milkdropReady && (
+          <div className="pointer-events-auto absolute bottom-6 left-1/2 flex -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-full bg-black/60 px-3 py-2">
+            <button onClick={(e) => { e.stopPropagation(); toggleFreeze(); }} title="Freeze / unfreeze (K)" className={ctrlBtn(frozen)}>
+              {frozen ? '▶ Resume' : '⏸ Freeze'}
+            </button>
+            <button onClick={(e) => { e.stopPropagation(); stepFrame(); }} disabled={!frozen} title="Step one frame while frozen (.)" className={ctrlBtn(false, !frozen)}>
+              ⏭ Step
+            </button>
+            <button onClick={(e) => { e.stopPropagation(); setVisualizerAutoAdvance(!visualizerAutoAdvance); resetOverlayTimer(); }} title="Auto-advance (A)" className={ctrlBtn(visualizerAutoAdvance)}>
+              ⏩ Auto
+            </button>
+            <button onClick={(e) => { e.stopPropagation(); setVisualizerShuffle(!visualizerShuffle); resetOverlayTimer(); }} title="Shuffle on advance" className={ctrlBtn(visualizerShuffle)}>
+              🔀 Shuffle
+            </button>
+            <button onClick={(e) => { e.stopPropagation(); toggleFps(); }} title="FPS overlay (F)" className={ctrlBtn(showFps)}>
+              FPS
+            </button>
+          </div>
+        )}
       </div>
+
+      {/* FPS overlay — persists regardless of the auto-hiding controls */}
+      {showFps && (
+        <div className="pointer-events-none absolute bottom-2 left-2 rounded bg-black/60 px-2 py-1 font-mono text-xs text-green-400">
+          {fps} fps · {milkdropEngine === 'projectm' ? 'projectM/WebGPU' : mode === 'milkdrop' ? 'butterchurn/WebGL' : 'shader/WebGL'}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -11,6 +11,10 @@ const NOTIFICATIONS_KEY = 'vibrdrome_notifications';
 const SLEEP_FADE_KEY = 'vibrdrome_sleep_fade_duration';
 const REPLAYGAIN_MODE_KEY = 'vibrdrome_replaygain_mode';
 const QUEUE_SYNC_KEY = 'vibrdrome_queue_sync';
+const VIS_FORCE_BUTTERCHURN_KEY = 'vibrdrome_visualizer_force_butterchurn';
+const VIS_AUTO_ADVANCE_KEY = 'vibrdrome_visualizer_auto_advance';
+const VIS_AUTO_ADVANCE_INTERVAL_KEY = 'vibrdrome_visualizer_auto_advance_interval';
+const VIS_SHUFFLE_KEY = 'vibrdrome_visualizer_shuffle';
 const DEFAULT_ACCENT = '#8b5cf6';
 
 type Theme = 'system' | 'dark' | 'light' | 'apple' | 'apple-dark' | 'retro' | 'terminal' | 'midnight' | 'sunset';
@@ -51,6 +55,16 @@ interface UIState {
 
   queueSyncEnabled: boolean;
   setQueueSyncEnabled: (value: boolean) => void;
+
+  // Visualizer (projectM / Milkdrop) preferences
+  visualizerForceButterchurn: boolean;
+  setVisualizerForceButterchurn: (value: boolean) => void;
+  visualizerAutoAdvance: boolean;
+  setVisualizerAutoAdvance: (value: boolean) => void;
+  visualizerAutoAdvanceInterval: number; // seconds
+  setVisualizerAutoAdvanceInterval: (seconds: number) => void;
+  visualizerShuffle: boolean;
+  setVisualizerShuffle: (value: boolean) => void;
 
   castConnected: boolean;
   setCastConnected: (connected: boolean) => void;
@@ -179,6 +193,33 @@ export const useUIStore = create<UIState>((set) => ({
   setQueueSyncEnabled: (value) => {
     try { localStorage.setItem(QUEUE_SYNC_KEY, String(value)); } catch { /* ignore */ }
     set({ queueSyncEnabled: value });
+  },
+
+  visualizerForceButterchurn: loadBool(VIS_FORCE_BUTTERCHURN_KEY, false),
+  setVisualizerForceButterchurn: (value) => {
+    try { localStorage.setItem(VIS_FORCE_BUTTERCHURN_KEY, String(value)); } catch { /* ignore */ }
+    set({ visualizerForceButterchurn: value });
+  },
+
+  visualizerAutoAdvance: loadBool(VIS_AUTO_ADVANCE_KEY, false),
+  setVisualizerAutoAdvance: (value) => {
+    try { localStorage.setItem(VIS_AUTO_ADVANCE_KEY, String(value)); } catch { /* ignore */ }
+    set({ visualizerAutoAdvance: value });
+  },
+
+  visualizerAutoAdvanceInterval: (() => {
+    try { return Number(localStorage.getItem(VIS_AUTO_ADVANCE_INTERVAL_KEY)) || 15; }
+    catch { return 15; }
+  })(),
+  setVisualizerAutoAdvanceInterval: (seconds) => {
+    try { localStorage.setItem(VIS_AUTO_ADVANCE_INTERVAL_KEY, String(seconds)); } catch { /* ignore */ }
+    set({ visualizerAutoAdvanceInterval: seconds });
+  },
+
+  visualizerShuffle: loadBool(VIS_SHUFFLE_KEY, false),
+  setVisualizerShuffle: (value) => {
+    try { localStorage.setItem(VIS_SHUFFLE_KEY, String(value)); } catch { /* ignore */ }
+    set({ visualizerShuffle: value });
   },
 
   castConnected: false,


### PR DESCRIPTION
## What changed
App-level controls for the Milkdrop visualizer (no transitions, screenshots, or GPU readback).
- **Settings (`uiStore`, persisted):** force-butterchurn, auto-advance + interval (5–60s), shuffle. Rendered in a new `SettingsScreen` "Visualizer" section using the existing toggle/select pattern.
- **`VisualizerScreen`:** auto-advance interval timer (shuffle-aware); freeze + single-step and an FPS overlay (applied to both projectM and butterchurn loops); HUD line (engine · idx/total · AUTO/SHUF/FROZEN); a bottom control bar; visualizer-scoped keyboard shortcuts `N/P/A/[/]/K/./F` (latest-logic-in-ref listener; honors the master shortcuts toggle; avoids the global handler's keys), documented in `ShortcutsOverlay` (opened by `?`).
- Shader mode, butterchurn fallback, and hard-cut switching unchanged.

## Verification
- `npm run lint` ✓ · `npm run test:run` ✓ 163 pass · `npm run build` ✓ · `docker build` ✓
## Manual testing
Verified: force-butterchurn switches engine; auto-advance + interval; shuffle; freeze/step; FPS toggle; HUD + `?` overlay; settings persist across reload; shader mode intact; clean teardown on leave.

## Dependency / base note
**Stacked PR — base: `projectm-visualizer-integration` (PR 4).** Builds on the integration. Merge after PR 4.

## Deferred (not in scope)
Transitions/crossfade, screenshots, async black-frame detection — deferred.