### PR TITLE
Prepare 1.9.0-beta.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,20 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
-## [ Unreleased ]
-- Document Picture-in-Picture support (Chrome native PiP window)
+## [1.9.0-beta.1] - 2026-06-19
+
+### Added
+- **projectM Milkdrop visualizer** — a WebGPU-based Milkdrop engine using projectM-rs compiled to WebAssembly. projectM is used as the primary Milkdrop visualizer when WebGPU is available, with butterchurn retained as the WebGL fallback.
+- Official projectM preset corpus bundled with 10,347 presets as gzipped shards, cached in IndexedDB with lazy per-category loading.
+- Visualizer controls for auto-advance with interval, shuffle, freeze, single-step, FPS overlay, info HUD, and keyboard shortcuts.
+- Settings → Visualizer options for force-butterchurn engine, auto-advance, auto-advance interval, and shuffle.
+- Documented Picture-in-Picture support.
+
+### Changed
+- The Milkdrop visualizer now reacts to live playback audio through the PlaybackManager analyser.
+
+### Licensing
+- Added LGPL-2.1 license text, source availability notice, and app-visible attribution for the vendored projectM-rs visualizer engine.
 
 ## [1.8.1-beta.2] - 2026-05-05
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.8.1-beta.2",
+  "version": "1.9.0-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -523,7 +523,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.8.1-beta.2</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.1</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">


### PR DESCRIPTION
## What changed
Release metadata only for the projectM Milkdrop visualizer work (PRs #28–#31, already merged to `develop`):
- `package.json` version `1.8.1-beta.2` → `1.9.0-beta.1` (new capability → minor bump)
- Settings → About version string updated to match
- `CHANGELOG.md`: new `1.9.0-beta.1` entry (Added / Changed / Licensing); the prior Unreleased "Picture-in-Picture" note folded into it

No code or feature changes.

## Verification
- `npm run lint` ✓ · `npm run test:run` ✓ 163 pass · `npm run build` ✓ · `docker build` ✓ (162 MB)
- Version consistent across package.json + About.

## Base note
Branched from `develop @ c691b0a`; up to date (not behind). Lands the version bump on `develop` ahead of the deliberate `develop → master` production release.