### PR TITLE
Fix intermittent PlaybackManager test teardown flake

### DIFF
--- a/src/stores/playerStore.test.ts
+++ b/src/stores/playerStore.test.ts
@@ -1,6 +1,17 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { usePlayerStore } from './playerStore';
 import type { Song } from '../types/subsonic';
+
+// playerStore actions (playSongs → stopRadio, seek) fire-and-forget a dynamic
+// `import('../audio/PlaybackManager')`. In tests that import can resolve AFTER
+// Vitest has torn the environment down, surfacing as an intermittent
+// `EnvironmentTeardownError` while loading PlaybackManager → SubsonicClient.
+// Mock the module here — file-local, so PlaybackManager.test.ts still exercises
+// the real implementation — so the dynamic import resolves to a no-op and never
+// loads the real module chain after teardown. Test-only; no runtime change.
+vi.mock('../audio/PlaybackManager', () => ({
+  getPlaybackManager: () => ({ seek: () => {}, stopRadio: () => {} }),
+}));
 
 // Reset store between tests
 beforeEach(() => {


### PR DESCRIPTION
## Root cause
`playerStore` actions (`playSongs` → `stopRadio`, `seek`) fire-and-forget a dynamic `import('../audio/PlaybackManager')`. In tests, that import can resolve **after** Vitest tears the environment down → intermittent `EnvironmentTeardownError` loading `PlaybackManager → SubsonicClient`. It failed PR #32's `test` check once and passed on re-run.

## Fix
A **file-local** `vi.mock('../audio/PlaybackManager')` in `playerStore.test.ts` so the dynamic import resolves to a no-op and never loads the real module chain after teardown. `PlaybackManager.test.ts` keeps the real implementation. **Test-only — no runtime behavior change.**

## Verification
- `npm run test:run` **5/5: exit 0, 163 passed, 0 teardown errors** (was consistently exit 1 / 3 errors)
- `npm run lint` ✓ · `npm run build` ✓ · `docker build` ✓
- Diff: `src/stores/playerStore.test.ts` only.

Small test-hygiene PR ahead of the `develop → master` release so the production PR doesn't depend on a CI re-run.