### PR TITLE
Prepare 1.9.0-beta.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.2] - 2026-06-20
+
+### Fixed
+- Production black-screen on load: Vite 8.0.10 chunked `zustand`'s `create` into the entry chunk, creating a circular entry ↔ `uiStore` dependency — `uiStore` evaluated before `create` was initialized (`TypeError: create is not a function`), so React never mounted and `#root` stayed empty. (Regression in 1.9.0-beta.1.)
+
+### Changed
+- Pinned Vite to 8.0.9 (the chunk output that keeps `create` in a vendor chunk) pending an upstream-safe upgrade path.
+
+### Added
+- Production-preview smoke test (`npm run test:smoke`): builds the app, serves the minified bundle via `vite preview`, loads it in headless Chromium, and fails on console errors or an empty `#root`. Wired into the required CI build job so production-bundle-only crashes are caught before release.
+
+### Notes
+- No projectM visualizer behavior changed; this release is the 1.9.0-beta.1 feature set plus the production-bundle fix and smoke guard.
+
 ## [1.9.0-beta.1] - 2026-06-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.1",
+  "version": "1.9.0-beta.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -523,7 +523,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.1</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.2</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">


### PR DESCRIPTION
## What changed
Release metadata only — re-release of the 1.9.0-beta.1 feature set with the production black-screen fixed.
- `package.json` version `1.9.0-beta.1` → `1.9.0-beta.2`
- Settings → About version updated to match
- `CHANGELOG.md`: `1.9.0-beta.2` entry (Fixed the vite-8.0.10 chunking crash; pinned vite 8.0.9; added the production-preview smoke test)

`1.9.0-beta.1` is burned (shipped broken, rolled back). No code/feature changes here.

## Verification
- `npm run lint` ✓ · `npm run test:run` ✓ 163 · `npm run build` ✓ · `npm run test:smoke` ✓ (root mounted, 0 console errors) · `docker build` ✓
- Version consistent across package.json + About.

## Base note
Off the **fixed** `develop` (vite 8.0.9 + smoke guard). Lands the version bump on `develop` ahead of the deliberate `develop → master` re-release.