### PR TITLE
Add in-visualizer playback controls

### DIFF
--- a/src/components/visualizer/VisualizerTransport.test.tsx
+++ b/src/components/visualizer/VisualizerTransport.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import VisualizerTransport from './VisualizerTransport';
+import { usePlayerStore } from '../../stores/playerStore';
+import type { Song } from '../../types/subsonic';
+
+// Mock PlaybackManager so the component's getVolume()/seek()/volume calls never
+// load the real PlaybackManager → SubsonicClient chain (which can resolve after
+// Vitest teardown). Same rationale as playerStore.test.ts.
+const setVolume = vi.fn();
+const toggleMute = vi.fn();
+const seek = vi.fn();
+vi.mock('../../audio/PlaybackManager', () => ({
+  getPlaybackManager: () => ({
+    getVolume: () => 1,
+    setVolume,
+    toggleMute,
+    seek,
+    pauseRadio: () => {},
+    resumeRadio: () => {},
+  }),
+}));
+
+// Stub the heavy children — they pull in canvas / network / IntersectionObserver
+// not relevant to the transport's own logic, and are covered elsewhere.
+vi.mock('../common/CoverArt', () => ({ default: () => <div data-testid="cover" /> }));
+vi.mock('../player/WaveformSeekbar', () => ({ default: () => <div data-testid="seekbar" /> }));
+
+const makeSong = (id: string, title = `Song ${id}`): Song => ({
+  id,
+  title,
+  artist: `Artist ${id}`,
+  album: 'Test Album',
+  duration: 180,
+});
+
+beforeEach(() => {
+  setVolume.mockClear();
+  toggleMute.mockClear();
+  seek.mockClear();
+  usePlayerStore.setState({
+    queue: [],
+    currentIndex: -1,
+    currentSong: null,
+    isPlaying: false,
+    positionMs: 0,
+    durationMs: 0,
+    radioMode: null,
+    radioPlaying: false,
+    repeatMode: 'off',
+    shuffleEnabled: false,
+    shuffleOrder: [],
+  });
+});
+
+describe('VisualizerTransport', () => {
+  it('renders nothing when there is no current song or radio', () => {
+    const { container } = render(<VisualizerTransport onInteract={() => {}} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the current track title and artist', () => {
+    const song = makeSong('1', 'Song One');
+    usePlayerStore.setState({ queue: [song], currentIndex: 0, currentSong: song });
+    render(<VisualizerTransport onInteract={() => {}} />);
+    expect(screen.getByText('Song One')).toBeInTheDocument();
+    expect(screen.getByText('Artist 1')).toBeInTheDocument();
+  });
+
+  it('toggles play state and fires onInteract on play/pause (reusing the store action)', () => {
+    const song = makeSong('1', 'One');
+    usePlayerStore.setState({ queue: [song], currentIndex: 0, currentSong: song, isPlaying: false });
+    const onInteract = vi.fn();
+    render(<VisualizerTransport onInteract={onInteract} />);
+    fireEvent.click(screen.getByLabelText('Play'));
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+    // Fires from the button handler and again as the click bubbles to the
+    // wrapper (which wakes the overlay) — both wake the timer, which is fine.
+    expect(onInteract).toHaveBeenCalled();
+  });
+
+  it('advances to the next track via the existing store action', () => {
+    const queue = [makeSong('1', 'One'), makeSong('2', 'Two')];
+    usePlayerStore.setState({ queue, currentIndex: 0, currentSong: queue[0] });
+    render(<VisualizerTransport onInteract={() => {}} />);
+    fireEvent.click(screen.getByLabelText('Next track'));
+    expect(usePlayerStore.getState().currentSong?.title).toBe('Two');
+  });
+
+  it('goes to the previous track via the existing store action', () => {
+    const queue = [makeSong('1', 'One'), makeSong('2', 'Two')];
+    usePlayerStore.setState({ queue, currentIndex: 1, currentSong: queue[1], positionMs: 0 });
+    render(<VisualizerTransport onInteract={() => {}} />);
+    fireEvent.click(screen.getByLabelText('Previous track'));
+    expect(usePlayerStore.getState().currentSong?.title).toBe('One');
+  });
+
+  it('mutes via the existing PlaybackManager API', () => {
+    const song = makeSong('1', 'One');
+    usePlayerStore.setState({ queue: [song], currentIndex: 0, currentSong: song });
+    render(<VisualizerTransport onInteract={() => {}} />);
+    fireEvent.click(screen.getByLabelText('Mute'));
+    expect(toggleMute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/visualizer/VisualizerTransport.tsx
+++ b/src/components/visualizer/VisualizerTransport.tsx
@@ -1,0 +1,155 @@
+import { useState, useCallback } from 'react';
+import { usePlayerStore } from '../../stores/playerStore';
+import { getPlaybackManager } from '../../audio/PlaybackManager';
+import CoverArt from '../common/CoverArt';
+import WaveformSeekbar from '../player/WaveformSeekbar';
+
+interface VisualizerTransportProps {
+  /** Called on any interaction so the auto-hiding overlay timer resets. */
+  onInteract: () => void;
+}
+
+/**
+ * Compact now-playing transport rendered inside the visualizer overlay.
+ *
+ * Reuses existing playback state/logic (no duplication): playerStore for state
+ * and next/previous/togglePlay, PlaybackManager for seek/volume, and the shared
+ * CoverArt + WaveformSeekbar components (same seek idiom as PopOutPlayer).
+ *
+ * Click/tap only — no keyboard shortcuts (the document-level shortcuts in
+ * usePlayback already cover playback). Stops event propagation in the bubble
+ * phase so interacting here never triggers the canvas click/double-click
+ * (overlay timer / random preset); children still handle their own clicks first.
+ */
+export default function VisualizerTransport({ onInteract }: VisualizerTransportProps) {
+  const {
+    currentSong, isPlaying, positionMs, durationMs,
+    togglePlay, next, previous, radioMode, radioPlaying,
+  } = usePlayerStore();
+  const [volume, setVolume] = useState(() => Math.round(getPlaybackManager().getVolume() * 100));
+
+  const isRadio = !!radioMode;
+  const title = isRadio ? radioMode.stationName : currentSong?.title;
+  const subtitle = isRadio ? 'Radio' : currentSong?.artist;
+  const coverArt = isRadio ? radioMode.coverArt : currentSong?.coverArt;
+  const playing = isRadio ? radioPlaying : isPlaying;
+
+  const handleTogglePlay = useCallback(() => {
+    if (isRadio) {
+      const pm = getPlaybackManager();
+      if (radioPlaying) pm.pauseRadio(); else pm.resumeRadio();
+      usePlayerStore.setState({ radioPlaying: !radioPlaying });
+    } else {
+      togglePlay();
+    }
+    onInteract();
+  }, [isRadio, radioPlaying, togglePlay, onInteract]);
+
+  const handlePrev = useCallback(() => { previous(); onInteract(); }, [previous, onInteract]);
+  const handleNext = useCallback(() => { next(); onInteract(); }, [next, onInteract]);
+
+  const handleVolumeChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = Number(e.target.value);
+    setVolume(v);
+    getPlaybackManager().setVolume(v / 100);
+    onInteract();
+  }, [onInteract]);
+
+  const handleMute = useCallback(() => {
+    const pm = getPlaybackManager();
+    pm.toggleMute();
+    setVolume(Math.round(pm.getVolume() * 100));
+    onInteract();
+  }, [onInteract]);
+
+  // Nothing playing → render nothing. The smoke test loads with no playback, so
+  // this path must never throw or log.
+  if (!currentSong && !radioMode) return null;
+
+  const btn = 'flex h-11 w-11 items-center justify-center rounded-full text-white/80 transition-colors hover:bg-white/10 hover:text-white';
+
+  return (
+    <div
+      className="pointer-events-auto absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent px-3 pt-6 pb-3"
+      onClick={(e) => { e.stopPropagation(); onInteract(); }}
+      onDoubleClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => { e.stopPropagation(); onInteract(); }}
+      onTouchStart={(e) => { e.stopPropagation(); onInteract(); }}
+    >
+      <div className="mx-auto flex max-w-3xl items-center gap-3">
+        <CoverArt coverArt={coverArt} size={44} className="shrink-0 rounded-md" />
+
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-white">{title || 'Unknown'}</p>
+          {subtitle && <p className="truncate text-xs text-white/60">{subtitle}</p>}
+        </div>
+
+        <div className="flex items-center gap-1">
+          {!isRadio && (
+            <button onClick={handlePrev} className={btn} aria-label="Previous track">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5">
+                <path d="M6 6h2v12H6V6zm3.5 6l8.5 6V6l-8.5 6z" />
+              </svg>
+            </button>
+          )}
+          <button onClick={handleTogglePlay} className={`${btn} bg-white/10`} aria-label={playing ? 'Pause' : 'Play'}>
+            {playing ? (
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5">
+                <path d="M6 4h4v16H6V4zm8 0h4v16h-4V4z" />
+              </svg>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="ml-0.5 h-5 w-5">
+                <path d="M8 5v14l11-7L8 5z" />
+              </svg>
+            )}
+          </button>
+          {!isRadio && (
+            <button onClick={handleNext} className={btn} aria-label="Next track">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5">
+                <path d="M16 6h2v12h-2V6zM4 18l8.5-6L4 6v12z" />
+              </svg>
+            </button>
+          )}
+        </div>
+
+        {/* Volume — desktop only; mobile relies on hardware volume. */}
+        <div className="hidden items-center gap-1 sm:flex">
+          <button onClick={handleMute} className={btn} aria-label={volume === 0 ? 'Unmute' : 'Mute'}>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="h-5 w-5">
+              {volume === 0 ? (
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 6L7.5 9.5H4v5h3.5L12 18V6zM16 9l4 4m0-4l-4 4" />
+              ) : (
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.536 8.464a5 5 0 010 7.072M12 6L7.5 9.5H4v5h3.5L12 18V6z" />
+              )}
+            </svg>
+          </button>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={volume}
+            onChange={handleVolumeChange}
+            aria-label="Volume"
+            className="h-1 w-20 cursor-pointer appearance-none rounded-full bg-white/20 accent-accent [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white"
+          />
+        </div>
+      </div>
+
+      {/* Seekbar — songs only (radio has no scrubbable duration). */}
+      {!isRadio && (
+        <div className="mx-auto mt-1 max-w-3xl" style={{ height: 28 }}>
+          <WaveformSeekbar
+            songId={currentSong?.id}
+            progress={durationMs > 0 ? positionMs / durationMs : 0}
+            onSeek={(p) => {
+              const ms = Math.round(p * durationMs);
+              getPlaybackManager().seek(ms);
+              usePlayerStore.getState().setPosition(ms);
+              onInteract();
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -20,6 +20,7 @@ export default function SettingsScreen() {
     visualizerAutoAdvance, setVisualizerAutoAdvance,
     visualizerAutoAdvanceInterval, setVisualizerAutoAdvanceInterval,
     visualizerShuffle, setVisualizerShuffle,
+    visualizerShowTransport, setVisualizerShowTransport,
   } = useUIStore();
   const eqEnabled = useEQStore((s) => s.enabled);
 
@@ -365,6 +366,30 @@ export default function SettingsScreen() {
                     <span
                       className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
                         visualizerShuffle ? 'translate-x-5' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
+              </div>
+
+              {/* Show playback controls */}
+              <div className="border-t border-border pt-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <span className="text-sm text-text-primary">Show playback controls</span>
+                    <p className="text-xs text-text-muted">Show now-playing transport (play, skip, seek) in the visualizer overlay</p>
+                  </div>
+                  <button
+                    role="switch"
+                    aria-checked={visualizerShowTransport}
+                    onClick={() => setVisualizerShowTransport(!visualizerShowTransport)}
+                    className={`relative h-6 w-11 rounded-full transition-colors ${
+                      visualizerShowTransport ? 'bg-accent' : 'bg-bg-tertiary'
+                    }`}
+                  >
+                    <span
+                      className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                        visualizerShowTransport ? 'translate-x-5' : 'translate-x-0'
                       }`}
                     />
                   </button>

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -2,7 +2,9 @@ import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getPlaybackManager } from '../audio/PlaybackManager';
 import { useUIStore } from '../stores/uiStore';
+import { usePlayerStore } from '../stores/playerStore';
 import { usePresetStore } from '../stores/presetStore';
+import VisualizerTransport from '../components/visualizer/VisualizerTransport';
 import type { PresetIndexEntry } from '../types/presets';
 
 // projectM preset category that is excluded from normal selection: these are
@@ -214,8 +216,15 @@ export default function VisualizerScreen() {
     visualizerAutoAdvance, setVisualizerAutoAdvance,
     visualizerAutoAdvanceInterval, setVisualizerAutoAdvanceInterval,
     visualizerShuffle, setVisualizerShuffle,
+    visualizerShowTransport,
     keyboardShortcutsEnabled,
   } = useUIStore();
+
+  // Subscribed only to decide whether the in-overlay transport renders (so the
+  // bottom control bar / FPS overlay can shift up to make room for it).
+  const transportSong = usePlayerStore((s) => s.currentSong);
+  const transportRadio = usePlayerStore((s) => s.radioMode);
+  const transportVisible = visualizerShowTransport && (!!transportSong || !!transportRadio);
 
   const [mode, setMode] = useState<'shader' | 'milkdrop'>('shader');
   const [frozen, setFrozen] = useState(false);
@@ -957,9 +966,9 @@ export default function VisualizerScreen() {
           </>
         )}
 
-        {/* Milkdrop control bar */}
+        {/* Milkdrop control bar — shifts up when the transport occupies the bottom */}
         {mode === 'milkdrop' && milkdropReady && (
-          <div className="pointer-events-auto absolute bottom-6 left-1/2 flex -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-full bg-black/60 px-3 py-2">
+          <div className={`pointer-events-auto absolute left-1/2 flex -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-full bg-black/60 px-3 py-2 ${transportVisible ? 'bottom-28' : 'bottom-6'}`}>
             <button onClick={(e) => { e.stopPropagation(); toggleFreeze(); }} title="Freeze / unfreeze (K)" className={ctrlBtn(frozen)}>
               {frozen ? '▶ Resume' : '⏸ Freeze'}
             </button>
@@ -977,11 +986,14 @@ export default function VisualizerScreen() {
             </button>
           </div>
         )}
+
+        {/* In-visualizer playback transport (opt-in; self-hides with no song) */}
+        {visualizerShowTransport && <VisualizerTransport onInteract={resetOverlayTimer} />}
       </div>
 
       {/* FPS overlay — persists regardless of the auto-hiding controls */}
       {showFps && (
-        <div className="pointer-events-none absolute bottom-2 left-2 rounded bg-black/60 px-2 py-1 font-mono text-xs text-green-400">
+        <div className={`pointer-events-none absolute left-2 rounded bg-black/60 px-2 py-1 font-mono text-xs text-green-400 ${transportVisible ? 'bottom-24' : 'bottom-2'}`}>
           {fps} fps · {milkdropEngine === 'projectm' ? 'projectM/WebGPU' : mode === 'milkdrop' ? 'butterchurn/WebGL' : 'shader/WebGL'}
         </div>
       )}

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -15,6 +15,7 @@ const VIS_FORCE_BUTTERCHURN_KEY = 'vibrdrome_visualizer_force_butterchurn';
 const VIS_AUTO_ADVANCE_KEY = 'vibrdrome_visualizer_auto_advance';
 const VIS_AUTO_ADVANCE_INTERVAL_KEY = 'vibrdrome_visualizer_auto_advance_interval';
 const VIS_SHUFFLE_KEY = 'vibrdrome_visualizer_shuffle';
+const VIS_SHOW_TRANSPORT_KEY = 'vibrdrome_visualizer_show_transport';
 const DEFAULT_ACCENT = '#8b5cf6';
 
 type Theme = 'system' | 'dark' | 'light' | 'apple' | 'apple-dark' | 'retro' | 'terminal' | 'midnight' | 'sunset';
@@ -65,6 +66,8 @@ interface UIState {
   setVisualizerAutoAdvanceInterval: (seconds: number) => void;
   visualizerShuffle: boolean;
   setVisualizerShuffle: (value: boolean) => void;
+  visualizerShowTransport: boolean;
+  setVisualizerShowTransport: (value: boolean) => void;
 
   castConnected: boolean;
   setCastConnected: (connected: boolean) => void;
@@ -220,6 +223,13 @@ export const useUIStore = create<UIState>((set) => ({
   setVisualizerShuffle: (value) => {
     try { localStorage.setItem(VIS_SHUFFLE_KEY, String(value)); } catch { /* ignore */ }
     set({ visualizerShuffle: value });
+  },
+  // Conservative default: off. The transport self-hides with no song, so this
+  // keeps existing behavior (and the smoke test) unchanged until opted in.
+  visualizerShowTransport: loadBool(VIS_SHOW_TRANSPORT_KEY, false),
+  setVisualizerShowTransport: (value) => {
+    try { localStorage.setItem(VIS_SHOW_TRANSPORT_KEY, String(value)); } catch { /* ignore */ }
+    set({ visualizerShowTransport: value });
   },
 
   castConnected: false,


### PR DESCRIPTION
## Summary

Adds optional in-visualizer playback controls (PR 2 of the visualizer polish pass).

- Adds a now-playing transport inside the visualizer overlay: cover art, title/artist, play/pause, previous, next, seek, and (desktop) volume/mute.
- Adds a new `VisualizerTransport` component (`src/components/visualizer/`).
- Adds a `visualizerShowTransport` setting, **default OFF**, with a Settings toggle ("Show playback controls").
- Reuses existing playback APIs and components — no duplicated playback logic:
  - `usePlayerStore` (`currentSong/isPlaying/positionMs/durationMs/togglePlay/next/previous/radioMode/radioPlaying`)
  - `getPlaybackManager()` (`seek/getVolume/setVolume/toggleMute/pauseRadio/resumeRadio`)
  - `CoverArt`
  - `WaveformSeekbar` (same seek idiom as `PopOutPlayer`)
- Adds 6 focused tests for `VisualizerTransport`.
- Controls are **click/tap only** — no new keyboard shortcuts (existing document-level shortcuts already cover playback).

### Behavior / safety notes (preserved)
- Transport renders **nothing** when there is no current song / radio mode.
- With the setting **OFF**, visualizer behavior (and the smoke test) is unchanged.
- Event isolation: transport clicks/touches/double-clicks are stopped in the bubble phase so they never reach the canvas (no preset randomize / no stray timer reset); children still handle their own clicks.
- Overlay auto-hide timer resets on interaction; control bar / FPS overlay shift up only when the transport is visible.
- Mobile hides the volume slider (`hidden sm:flex`) — uses hardware volume.
- Existing fullscreen toggle, and the bare-canvas double-click → random preset, both remain intact.

### Out of scope (untouched)
- No dependency changes. No release/version/tag metadata changes. No projectM-rs changes. No HUD polish, particles, or crossfade work.

## Files changed (5)
- `src/components/visualizer/VisualizerTransport.tsx` (new)
- `src/components/visualizer/VisualizerTransport.test.tsx` (new)
- `src/screens/VisualizerScreen.tsx`
- `src/stores/uiStore.ts`
- `src/screens/SettingsScreen.tsx`

## Test plan

Local (all passing):
- `npm run lint` — clean
- `npm run test:run` — **169 passed** (6 new)
- `npm run build` — succeeds
- `npm run test:smoke` — `root mounted: true · console errors: 0 · PASS`

Interactive verification (real Chromium against the production build), 19/19: setting OFF hides transport; setting ON + no song renders nothing without crashing (0 console errors); setting ON + song shows title/artist/controls; play-pause/next/previous/seek work; transport interaction does not randomize presets; bare-canvas double-click still randomizes; fullscreen still works; overlay still auto-hides; mobile keeps 44px controls and hides the volume slider.

> Known caveat: a fake/aborted-source test harness can log a `PlaybackManager` resume error when Play is clicked without a real stream — not a transport bug; does not occur with a real playable source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)