### PR TITLE
Add visualizer HUD polish

### DIFF
--- a/src/components/visualizer/VisualizerHud.test.tsx
+++ b/src/components/visualizer/VisualizerHud.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import VisualizerHud from './VisualizerHud';
+
+describe('VisualizerHud', () => {
+  it('shows only the preset name in shader mode (engine null, no badges)', () => {
+    render(
+      <VisualizerHud
+        presetName="Plasma"
+        engine={null}
+        index={1}
+        total={6}
+        autoAdvance
+        shuffle
+        frozen
+      />,
+    );
+    expect(screen.getByText('Plasma')).toBeInTheDocument();
+    // Status badges are Milkdrop-only — none should render in shader mode.
+    expect(screen.queryByText('Auto')).not.toBeInTheDocument();
+    expect(screen.queryByText('Shuffle')).not.toBeInTheDocument();
+    expect(screen.queryByText('Frozen')).not.toBeInTheDocument();
+    expect(screen.queryByText('1 / 6')).not.toBeInTheDocument();
+  });
+
+  it('renders engine, position, and active status badges in Milkdrop mode', () => {
+    render(
+      <VisualizerHud
+        presetName="Geiss - Cosmic"
+        engine="projectm"
+        index={3}
+        total={120}
+        autoAdvance
+        shuffle={false}
+        frozen
+      />,
+    );
+    expect(screen.getByText('Geiss - Cosmic')).toBeInTheDocument();
+    expect(screen.getByText('projectM')).toBeInTheDocument();
+    expect(screen.getByText('3 / 120')).toBeInTheDocument();
+    expect(screen.getByText('Auto')).toBeInTheDocument();
+    expect(screen.getByText('Frozen')).toBeInTheDocument();
+    // shuffle is off → no Shuffle badge
+    expect(screen.queryByText('Shuffle')).not.toBeInTheDocument();
+  });
+
+  it('labels the butterchurn engine badge', () => {
+    render(
+      <VisualizerHud
+        presetName="Fallback"
+        engine="butterchurn"
+        index={1}
+        total={50}
+        autoAdvance={false}
+        shuffle={false}
+        frozen={false}
+      />,
+    );
+    expect(screen.getByText('butterchurn')).toBeInTheDocument();
+    expect(screen.getByText('1 / 50')).toBeInTheDocument();
+  });
+});

--- a/src/components/visualizer/VisualizerHud.tsx
+++ b/src/components/visualizer/VisualizerHud.tsx
@@ -1,0 +1,37 @@
+interface VisualizerHudProps {
+  presetName: string;
+  /** Active Milkdrop engine, or null in shader mode (no engine/status badges). */
+  engine: 'projectm' | 'butterchurn' | null;
+  index: number; // 1-based position
+  total: number;
+  autoAdvance: boolean;
+  shuffle: boolean;
+  frozen: boolean;
+}
+
+const badge = 'rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide';
+
+/**
+ * Top-center HUD: the current preset name plus, in Milkdrop mode, a row of
+ * status badges (engine, position, auto/shuffle/frozen). Pure/presentational —
+ * the toast and transition polish live in VisualizerScreen.
+ */
+export default function VisualizerHud({ presetName, engine, index, total, autoAdvance, shuffle, frozen }: VisualizerHudProps) {
+  return (
+    <div className="flex max-w-[60%] flex-col items-center gap-1">
+      <span className="truncate text-sm font-medium text-white/90">{presetName}</span>
+      {engine && (
+        <div className="flex flex-wrap items-center justify-center gap-1">
+          <span className={`${badge} flex items-center gap-1 bg-white/10 text-white/70`}>
+            <span className={`h-1.5 w-1.5 rounded-full ${engine === 'projectm' ? 'bg-accent' : 'bg-sky-400'}`} />
+            {engine === 'projectm' ? 'projectM' : 'butterchurn'}
+          </span>
+          {total > 0 && <span className={`${badge} bg-white/10 text-white/60`}>{index} / {total}</span>}
+          {autoAdvance && <span className={`${badge} bg-accent/30 text-white/85`}>Auto</span>}
+          {shuffle && <span className={`${badge} bg-accent/30 text-white/85`}>Shuffle</span>}
+          {frozen && <span className={`${badge} bg-sky-500/30 text-white/85`}>Frozen</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -21,6 +21,7 @@ export default function SettingsScreen() {
     visualizerAutoAdvanceInterval, setVisualizerAutoAdvanceInterval,
     visualizerShuffle, setVisualizerShuffle,
     visualizerShowTransport, setVisualizerShowTransport,
+    visualizerTransitionPolish, setVisualizerTransitionPolish,
   } = useUIStore();
   const eqEnabled = useEQStore((s) => s.enabled);
 
@@ -390,6 +391,30 @@ export default function SettingsScreen() {
                     <span
                       className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
                         visualizerShowTransport ? 'translate-x-5' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
+              </div>
+
+              {/* Transition polish */}
+              <div className="border-t border-border pt-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <span className="text-sm text-text-primary">Transition polish</span>
+                    <p className="text-xs text-text-muted">Subtle vignette dip when a preset changes (still a hard cut). Suppressed when Reduce Motion is on</p>
+                  </div>
+                  <button
+                    role="switch"
+                    aria-checked={visualizerTransitionPolish}
+                    onClick={() => setVisualizerTransitionPolish(!visualizerTransitionPolish)}
+                    className={`relative h-6 w-11 rounded-full transition-colors ${
+                      visualizerTransitionPolish ? 'bg-accent' : 'bg-bg-tertiary'
+                    }`}
+                  >
+                    <span
+                      className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                        visualizerTransitionPolish ? 'translate-x-5' : 'translate-x-0'
                       }`}
                     />
                   </button>

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -5,6 +5,8 @@ import { useUIStore } from '../stores/uiStore';
 import { usePlayerStore } from '../stores/playerStore';
 import { usePresetStore } from '../stores/presetStore';
 import VisualizerTransport from '../components/visualizer/VisualizerTransport';
+import VisualizerHud from '../components/visualizer/VisualizerHud';
+import { useMediaQuery } from '../hooks/useMediaQuery';
 import type { PresetIndexEntry } from '../types/presets';
 
 // projectM preset category that is excluded from normal selection: these are
@@ -217,8 +219,15 @@ export default function VisualizerScreen() {
     visualizerAutoAdvanceInterval, setVisualizerAutoAdvanceInterval,
     visualizerShuffle, setVisualizerShuffle,
     visualizerShowTransport,
+    visualizerTransitionPolish,
+    reduceMotion,
     keyboardShortcutsEnabled,
   } = useUIStore();
+
+  // Motion safety: suppress the transition polish under either the in-app
+  // reduce-motion setting or the OS prefers-reduced-motion media query.
+  const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+  const motionReduced = reduceMotion || prefersReducedMotion;
 
   // Subscribed only to decide whether the in-overlay transport renders (so the
   // bottom control bar / FPS overlay can shift up to make room for it).
@@ -236,6 +245,11 @@ export default function VisualizerScreen() {
   const [milkdropReady, setMilkdropReady] = useState(false);
   const [showOverlay, setShowOverlay] = useState(true);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  // Transient toast showing the preset name when it changes.
+  const [presetToast, setPresetToast] = useState<string | null>(null); // controls visibility
+  const [toastText, setToastText] = useState(''); // retained during the toast's fade-out
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const vignetteRef = useRef<HTMLDivElement>(null);
   // Which Milkdrop engine is active: 'projectm' (WebGPU) or 'butterchurn'
   // (fallback), decided when milkdrop mode activates.
   const [milkdropEngine, setMilkdropEngine] = useState<'projectm' | 'butterchurn' | null>(null);
@@ -809,9 +823,36 @@ export default function VisualizerScreen() {
   const displayPresetName = mode === 'shader'
     ? currentPreset.name
     : (milkdropPresetNames[milkdropPresetIndex] || 'Loading...');
-  const hudInfo = mode === 'milkdrop' && milkdropEngine
-    ? `${milkdropEngine === 'projectm' ? 'projectM' : 'butterchurn'} · ${milkdropPresetIndex + 1}/${totalPresets || '…'}`
-    : null;
+
+  // On preset change: show a brief name toast, and (when enabled and motion is
+  // not reduced) pulse a subtle DOM/CSS vignette over the still-hard-cut switch.
+  // The actual preset switch is unchanged — this is purely cosmetic overlay.
+  const prevPresetNameRef = useRef<string | null>(null);
+  useEffect(() => {
+    const name = displayPresetName;
+    const prev = prevPresetNameRef.current;
+    prevPresetNameRef.current = name;
+    // Skip the initial mount and the transient "Loading..." placeholder.
+    if (prev === null || !name || name === 'Loading...' || name === prev) return;
+
+    setToastText(name);
+    setPresetToast(name);
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    toastTimerRef.current = setTimeout(() => setPresetToast(null), 1800);
+
+    if (visualizerTransitionPolish && !motionReduced) {
+      const el = vignetteRef.current;
+      if (el && typeof el.animate === 'function') {
+        // A short darken-edges pulse (0 → subtle → 0). No white flash.
+        el.animate(
+          [{ opacity: 0 }, { opacity: 0.55, offset: 0.35 }, { opacity: 0 }],
+          { duration: 260, easing: 'ease-out' },
+        );
+      }
+    }
+  }, [displayPresetName, visualizerTransitionPolish, motionReduced]);
+
+  useEffect(() => () => { if (toastTimerRef.current) clearTimeout(toastTimerRef.current); }, []);
 
   const ctrlBtn = (on: boolean, disabled = false) =>
     `rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
@@ -886,17 +927,16 @@ export default function VisualizerScreen() {
             </svg>
           </button>
 
-          {/* Preset name + HUD info (engine · index/total · status) */}
-          <div className="flex max-w-[55%] flex-col items-center">
-            <span className="truncate text-sm font-medium text-white/80">
-              {displayPresetName}
-            </span>
-            {hudInfo && (
-              <span className="mt-0.5 text-[10px] font-medium tracking-wide text-white/40">
-                {hudInfo}{visualizerAutoAdvance ? ' · AUTO' : ''}{visualizerShuffle ? ' · SHUF' : ''}{frozen ? ' · FROZEN' : ''}
-              </span>
-            )}
-          </div>
+          {/* Preset name + status badges (engine · index/total · auto/shuffle/frozen) */}
+          <VisualizerHud
+            presetName={displayPresetName}
+            engine={mode === 'milkdrop' ? milkdropEngine : null}
+            index={milkdropPresetIndex + 1}
+            total={totalPresets}
+            autoAdvance={visualizerAutoAdvance}
+            shuffle={visualizerShuffle}
+            frozen={frozen}
+          />
 
           {/* Right controls: fullscreen toggle (when supported) + mode toggle */}
           <div className="flex items-center gap-2">
@@ -997,6 +1037,25 @@ export default function VisualizerScreen() {
           {fps} fps · {milkdropEngine === 'projectm' ? 'projectM/WebGPU' : mode === 'milkdrop' ? 'butterchurn/WebGL' : 'shader/WebGL'}
         </div>
       )}
+
+      {/* Transition polish: subtle vignette pulse on preset change (opacity
+          animated via WAAPI only when enabled + motion not reduced). Hard cut
+          underneath is unchanged. */}
+      <div
+        ref={vignetteRef}
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-0"
+        style={{ background: 'radial-gradient(ellipse at center, transparent 55%, rgba(0,0,0,0.7) 100%)' }}
+      />
+
+      {/* Preset-name toast — brief, independent of the auto-hiding overlay */}
+      <div
+        className={`pointer-events-none absolute top-[22%] left-1/2 -translate-x-1/2 rounded-full bg-black/60 px-4 py-1.5 text-sm font-medium text-white/90 backdrop-blur-sm transition-opacity ${
+          motionReduced ? '' : 'duration-300'
+        } ${presetToast ? 'opacity-100' : 'opacity-0'}`}
+      >
+        {toastText}
+      </div>
     </div>
   );
 }

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -16,6 +16,7 @@ const VIS_AUTO_ADVANCE_KEY = 'vibrdrome_visualizer_auto_advance';
 const VIS_AUTO_ADVANCE_INTERVAL_KEY = 'vibrdrome_visualizer_auto_advance_interval';
 const VIS_SHUFFLE_KEY = 'vibrdrome_visualizer_shuffle';
 const VIS_SHOW_TRANSPORT_KEY = 'vibrdrome_visualizer_show_transport';
+const VIS_TRANSITION_POLISH_KEY = 'vibrdrome_visualizer_transition_polish';
 const DEFAULT_ACCENT = '#8b5cf6';
 
 type Theme = 'system' | 'dark' | 'light' | 'apple' | 'apple-dark' | 'retro' | 'terminal' | 'midnight' | 'sunset';
@@ -68,6 +69,8 @@ interface UIState {
   setVisualizerShuffle: (value: boolean) => void;
   visualizerShowTransport: boolean;
   setVisualizerShowTransport: (value: boolean) => void;
+  visualizerTransitionPolish: boolean;
+  setVisualizerTransitionPolish: (value: boolean) => void;
 
   castConnected: boolean;
   setCastConnected: (connected: boolean) => void;
@@ -230,6 +233,13 @@ export const useUIStore = create<UIState>((set) => ({
   setVisualizerShowTransport: (value) => {
     try { localStorage.setItem(VIS_SHOW_TRANSPORT_KEY, String(value)); } catch { /* ignore */ }
     set({ visualizerShowTransport: value });
+  },
+  // Subtle DOM/CSS vignette dip around the (still hard-cut) preset switch.
+  // Default off; always suppressed under reduced motion. No engine changes.
+  visualizerTransitionPolish: loadBool(VIS_TRANSITION_POLISH_KEY, false),
+  setVisualizerTransitionPolish: (value) => {
+    try { localStorage.setItem(VIS_TRANSITION_POLISH_KEY, String(value)); } catch { /* ignore */ }
+    set({ visualizerTransitionPolish: value });
   },
 
   castConnected: false,


### PR DESCRIPTION
## Summary

Visualizer HUD / overlay polish (PR 3 of the visualizer polish pass). App/UI-only — no engine changes.

- Adds a new `VisualizerHud` component for the preset name + status badges (engine badge, position `N / total`, and Auto/Shuffle/Frozen pills). Improves preset/status display without changing engine behavior; shader mode shows just the name (unchanged).
- Adds focused HUD tests (`VisualizerHud.test.tsx`).
- Adds a **preset-name toast** — a brief centered pill shown on preset change, independent of the auto-hiding overlay.
- Adds an **optional, app-only transition vignette polish**: a subtle darken-edges pulse (opacity `0 → 0.55 → 0`, ~260ms, no white flash) on preset change, animated via the Web Animations API on a `pointer-events-none` gradient div.
- **Preset switching stays a hard cut** — the vignette is purely cosmetic overlay.
- Adds `visualizerTransitionPolish` setting, **default OFF** (existing `loadBool`/localStorage pattern + Settings toggle).
- **Suppresses the transition animation** when the in-app Reduce Motion setting **or** OS `prefers-reduced-motion: reduce` is active.

### Explicitly NOT done
- No second engine. No second canvas. No screenshot/readback. No WebGPU readback. No projectM-rs / WASM changes. No dependency changes. No release/version/tag metadata changes. No particles or real crossfade work.

## Files changed (5)
- `src/components/visualizer/VisualizerHud.tsx` (new)
- `src/components/visualizer/VisualizerHud.test.tsx` (new)
- `src/screens/VisualizerScreen.tsx`
- `src/stores/uiStore.ts`
- `src/screens/SettingsScreen.tsx`

## Test plan

Local (all passing):
- `npm run lint` — clean
- `npm run test:run` — **172 passed** (3 new)
- `npm run build` — succeeds
- `npm run test:smoke` — `root mounted: true · console errors: 0 · PASS`

Interactive verification (real Chromium against the production build), 16/16: preset name updates on N/P; toast appears with the new name and fades after ~1.8s; polish OFF → no vignette animation; polish ON → vignette pulse fires; `prefers-reduced-motion: reduce` → animation suppressed (toast still updates); fullscreen still works; double-click still randomizes preset; overlay still auto-hides; mobile (390px) name + toast render; 0 relevant console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)