### PR TITLE
Prepare 1.9.0-beta.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.3] - 2026-06-20
+
+### Added
+- Fullscreen toggle in the visualizer overlay — feature-detected, with WebKit fallbacks; hidden where the Fullscreen API is unsupported (e.g. iOS Safari).
+- Optional in-visualizer playback controls (now-playing transport: cover art, title/artist, play/pause, previous/next, seek, and desktop volume/mute), reusing the existing playback APIs and components. Default OFF.
+- Visualizer HUD polish: clearer preset name plus engine/position/auto/shuffle/frozen status badges, and a brief preset-name toast when the preset changes.
+- Optional, reduced-motion-safe transition vignette polish: a subtle DOM/CSS vignette dip around the (still hard-cut) preset switch. Default OFF.
+- Optional 2D-canvas particle overlay: a subtle audio-reactive particle layer with particle-count and device-pixel-ratio caps plus low-FPS throttling. Default OFF.
+
+### Notes
+- Particles and transition polish are opt-in and reduced-motion aware: both are suppressed when Reduce Motion or `prefers-reduced-motion: reduce` is active.
+- No projectM engine / WASM behavior changed; preset switching remains a hard cut. No real crossfade or screenshot/readback transition work is included.
+
 ## [1.9.0-beta.2] - 2026-06-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.2",
+  "version": "1.9.0-beta.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -598,7 +598,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.2</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.3</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">


### PR DESCRIPTION
## Summary

Release-prep metadata for **1.9.0-beta.3** (no functional code changes). Bundles the four merged app-only visualizer polish features for a beta cut.

Metadata-only diff:
- `package.json`: `1.9.0-beta.2` → `1.9.0-beta.3`
- `src/screens/SettingsScreen.tsx`: About string `v1.9.0-beta.2` → `v1.9.0-beta.3`
- `CHANGELOG.md`: new `1.9.0-beta.3` entry

### What 1.9.0-beta.3 ships (already merged to develop)
- #39 Fullscreen toggle in the visualizer overlay (feature-detected; hidden where unsupported, e.g. iOS Safari).
- #40 Optional in-visualizer playback controls (transport), default OFF.
- #41 Visualizer HUD/status-badge polish + preset-name toast, and an optional reduced-motion-safe transition vignette (default OFF).
- #42 Optional 2D-canvas particle overlay, default OFF.

Particles and transition polish are opt-in and reduced-motion aware. **No projectM engine / WASM behavior changed; preset switching remains a hard cut. No real crossfade or screenshot/readback work is included.**

## Test plan

Local (all passing on this branch):
- `npm run lint` — clean
- `npm run test:run` — 176 passed / 19 files
- `npm run build` — succeeds
- `npm run test:smoke` — `root mounted: true · console errors: 0 · PASS`
- `docker build -t vibrdrome-web:1.9.0-beta.3 .` — succeeds

No dependency changes. No tag/release/deploy in this PR (release to master is a separate step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)