### PR TITLE
Release 1.9.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.3] - 2026-06-20
+
+### Added
+- Fullscreen toggle in the visualizer overlay — feature-detected, with WebKit fallbacks; hidden where the Fullscreen API is unsupported (e.g. iOS Safari).
+- Optional in-visualizer playback controls (now-playing transport: cover art, title/artist, play/pause, previous/next, seek, and desktop volume/mute), reusing the existing playback APIs and components. Default OFF.
+- Visualizer HUD polish: clearer preset name plus engine/position/auto/shuffle/frozen status badges, and a brief preset-name toast when the preset changes.
+- Optional, reduced-motion-safe transition vignette polish: a subtle DOM/CSS vignette dip around the (still hard-cut) preset switch. Default OFF.
+- Optional 2D-canvas particle overlay: a subtle audio-reactive particle layer with particle-count and device-pixel-ratio caps plus low-FPS throttling. Default OFF.
+
+### Notes
+- Particles and transition polish are opt-in and reduced-motion aware: both are suppressed when Reduce Motion or `prefers-reduced-motion: reduce` is active.
+- No projectM engine / WASM behavior changed; preset switching remains a hard cut. No real crossfade or screenshot/readback transition work is included.
+
 ## [1.9.0-beta.2] - 2026-06-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.2",
+  "version": "1.9.0-beta.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/visualizer/ParticleOverlay.test.tsx
+++ b/src/components/visualizer/ParticleOverlay.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import ParticleOverlay from './ParticleOverlay';
+
+// No real audio chain. In happy-dom, canvas.getContext('2d') returns null, so
+// the component takes its silent-disable path — which is exactly the
+// "context unavailable" safety case we want to verify never throws.
+vi.mock('../../audio/PlaybackManager', () => ({
+  getPlaybackManager: () => ({ getAnalyser: () => null }),
+}));
+
+describe('ParticleOverlay', () => {
+  it('renders a pointer-events-none canvas without crashing', () => {
+    const { container } = render(<ParticleOverlay />);
+    const canvas = container.querySelector('canvas');
+    expect(canvas).not.toBeNull();
+    expect(canvas?.className).toContain('pointer-events-none');
+    expect(canvas?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('silently no-ops when the 2D context is unavailable (no throw)', () => {
+    // happy-dom returns null from getContext('2d'); mounting must not throw.
+    expect(() => render(<ParticleOverlay />)).not.toThrow();
+  });
+
+  it('unmounts cleanly without throwing', () => {
+    const { unmount } = render(<ParticleOverlay />);
+    expect(() => unmount()).not.toThrow();
+  });
+
+  it('does not throw when the analyser is null (no audio)', () => {
+    // Analyser is mocked to null above; a mount/unmount cycle must stay clean.
+    const { unmount } = render(<ParticleOverlay />);
+    unmount();
+    expect(true).toBe(true);
+  });
+});

--- a/src/components/visualizer/ParticleOverlay.tsx
+++ b/src/components/visualizer/ParticleOverlay.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useRef } from 'react';
+import { getPlaybackManager } from '../../audio/PlaybackManager';
+
+/**
+ * Optional, lightweight particle layer drawn on a separate 2D canvas above the
+ * visualizer engines and below the controls/HUD. App-only polish — it never
+ * touches projectM/butterchurn/shader rendering.
+ *
+ * Deliberately conservative: a small, capped pool of gently drifting dots whose
+ * brightness/drift is modulated by overall audio energy (from the existing
+ * analyser). No beat explosions, no flashes. Trails fade via destination-out so
+ * the canvas stays transparent (never darkens the underlying visualizer).
+ *
+ * Safety: silently no-ops if `getContext('2d')` is unavailable; idles calmly
+ * with no audio; caps particle count and DPR (lower on small screens);
+ * self-throttles when its own frame rate drops; cancels rAF and clears on
+ * unmount. The parent only mounts this when enabled and motion is not reduced.
+ */
+export default function ParticleOverlay() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return; // silent disable (e.g. context unavailable)
+
+    const small = window.innerWidth <= 480;
+    const dprCap = small ? 1 : 1.5;
+    const maxParticles = small ? 28 : 60;
+    let activeCap = maxParticles; // self-throttled down if FPS drops
+
+    interface P { x: number; y: number; vx: number; vy: number; r: number; base: number; }
+    const particles: P[] = [];
+
+    const rand = (a: number, b: number) => a + Math.random() * (b - a);
+
+    let w = 0, h = 0;
+    const resize = () => {
+      const dpr = Math.min(window.devicePixelRatio || 1, dprCap);
+      w = canvas.clientWidth;
+      h = canvas.clientHeight;
+      canvas.width = Math.max(1, Math.floor(w * dpr));
+      canvas.height = Math.max(1, Math.floor(h * dpr));
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+    resize();
+
+    const spawn = (): P => ({
+      x: rand(0, w || 1),
+      y: rand(0, h || 1),
+      vx: rand(-0.15, 0.15),
+      vy: rand(-0.35, -0.05), // gentle upward drift
+      r: rand(0.8, 2.2),
+      base: rand(0.15, 0.4),
+    });
+    for (let i = 0; i < maxParticles; i++) particles.push(spawn());
+
+    let audioBuf: Uint8Array<ArrayBuffer> | null = null;
+    const energy = (): number => {
+      const analyser = getPlaybackManager().getAnalyser();
+      if (!analyser) return 0; // no audio → calm idle
+      const n = analyser.frequencyBinCount;
+      if (!audioBuf || audioBuf.length !== n) audioBuf = new Uint8Array(n);
+      analyser.getByteFrequencyData(audioBuf);
+      // Average the lower half (bass/mids drive the motion), normalised 0..1.
+      const half = Math.max(1, n >> 1);
+      let sum = 0;
+      for (let i = 0; i < half; i++) sum += audioBuf[i];
+      return Math.min(1, sum / (half * 255));
+    };
+
+    let raf = 0;
+    let last = performance.now();
+    let smoothedDt = 16;
+    let smoothedEnergy = 0;
+
+    const frame = () => {
+      const now = performance.now();
+      const dt = now - last;
+      last = now;
+      // Self-throttle: if our own frame interval is sustained-slow (<~30fps),
+      // shrink the active particle cap; recover gently when it improves.
+      smoothedDt = smoothedDt * 0.9 + dt * 0.1;
+      if (smoothedDt > 33 && activeCap > 10) activeCap -= 1;
+      else if (smoothedDt < 22 && activeCap < maxParticles) activeCap += 1;
+
+      const e = energy();
+      smoothedEnergy = smoothedEnergy * 0.85 + e * 0.15;
+
+      // Fade existing trails toward transparent (keeps overlay non-darkening).
+      ctx.globalCompositeOperation = 'destination-out';
+      ctx.fillStyle = 'rgba(0,0,0,0.10)';
+      ctx.fillRect(0, 0, w, h);
+
+      // Additive, soft white dots.
+      ctx.globalCompositeOperation = 'lighter';
+      const speed = 0.5 + smoothedEnergy * 1.8;
+      const glow = 0.6 + smoothedEnergy * 0.9;
+      for (let i = 0; i < activeCap; i++) {
+        const p = particles[i];
+        p.x += p.vx * speed;
+        p.y += p.vy * speed;
+        // wrap around edges
+        if (p.y < -4) { p.y = h + 4; p.x = rand(0, w); }
+        if (p.x < -4) p.x = w + 4;
+        else if (p.x > w + 4) p.x = -4;
+        const a = Math.min(0.85, p.base * glow);
+        ctx.fillStyle = `rgba(255,255,255,${a})`;
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.globalCompositeOperation = 'source-over';
+      raf = requestAnimationFrame(frame);
+    };
+    raf = requestAnimationFrame(frame);
+
+    let resizeRaf = 0;
+    const onResize = () => { cancelAnimationFrame(resizeRaf); resizeRaf = requestAnimationFrame(resize); };
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      cancelAnimationFrame(resizeRaf);
+      window.removeEventListener('resize', onResize);
+      try { ctx.clearRect(0, 0, canvas.width, canvas.height); } catch { /* ignore */ }
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} aria-hidden="true" className="pointer-events-none absolute inset-0 h-full w-full" />;
+}

--- a/src/components/visualizer/VisualizerHud.test.tsx
+++ b/src/components/visualizer/VisualizerHud.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import VisualizerHud from './VisualizerHud';
+
+describe('VisualizerHud', () => {
+  it('shows only the preset name in shader mode (engine null, no badges)', () => {
+    render(
+      <VisualizerHud
+        presetName="Plasma"
+        engine={null}
+        index={1}
+        total={6}
+        autoAdvance
+        shuffle
+        frozen
+      />,
+    );
+    expect(screen.getByText('Plasma')).toBeInTheDocument();
+    // Status badges are Milkdrop-only — none should render in shader mode.
+    expect(screen.queryByText('Auto')).not.toBeInTheDocument();
+    expect(screen.queryByText('Shuffle')).not.toBeInTheDocument();
+    expect(screen.queryByText('Frozen')).not.toBeInTheDocument();
+    expect(screen.queryByText('1 / 6')).not.toBeInTheDocument();
+  });
+
+  it('renders engine, position, and active status badges in Milkdrop mode', () => {
+    render(
+      <VisualizerHud
+        presetName="Geiss - Cosmic"
+        engine="projectm"
+        index={3}
+        total={120}
+        autoAdvance
+        shuffle={false}
+        frozen
+      />,
+    );
+    expect(screen.getByText('Geiss - Cosmic')).toBeInTheDocument();
+    expect(screen.getByText('projectM')).toBeInTheDocument();
+    expect(screen.getByText('3 / 120')).toBeInTheDocument();
+    expect(screen.getByText('Auto')).toBeInTheDocument();
+    expect(screen.getByText('Frozen')).toBeInTheDocument();
+    // shuffle is off → no Shuffle badge
+    expect(screen.queryByText('Shuffle')).not.toBeInTheDocument();
+  });
+
+  it('labels the butterchurn engine badge', () => {
+    render(
+      <VisualizerHud
+        presetName="Fallback"
+        engine="butterchurn"
+        index={1}
+        total={50}
+        autoAdvance={false}
+        shuffle={false}
+        frozen={false}
+      />,
+    );
+    expect(screen.getByText('butterchurn')).toBeInTheDocument();
+    expect(screen.getByText('1 / 50')).toBeInTheDocument();
+  });
+});

--- a/src/components/visualizer/VisualizerHud.tsx
+++ b/src/components/visualizer/VisualizerHud.tsx
@@ -1,0 +1,37 @@
+interface VisualizerHudProps {
+  presetName: string;
+  /** Active Milkdrop engine, or null in shader mode (no engine/status badges). */
+  engine: 'projectm' | 'butterchurn' | null;
+  index: number; // 1-based position
+  total: number;
+  autoAdvance: boolean;
+  shuffle: boolean;
+  frozen: boolean;
+}
+
+const badge = 'rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide';
+
+/**
+ * Top-center HUD: the current preset name plus, in Milkdrop mode, a row of
+ * status badges (engine, position, auto/shuffle/frozen). Pure/presentational —
+ * the toast and transition polish live in VisualizerScreen.
+ */
+export default function VisualizerHud({ presetName, engine, index, total, autoAdvance, shuffle, frozen }: VisualizerHudProps) {
+  return (
+    <div className="flex max-w-[60%] flex-col items-center gap-1">
+      <span className="truncate text-sm font-medium text-white/90">{presetName}</span>
+      {engine && (
+        <div className="flex flex-wrap items-center justify-center gap-1">
+          <span className={`${badge} flex items-center gap-1 bg-white/10 text-white/70`}>
+            <span className={`h-1.5 w-1.5 rounded-full ${engine === 'projectm' ? 'bg-accent' : 'bg-sky-400'}`} />
+            {engine === 'projectm' ? 'projectM' : 'butterchurn'}
+          </span>
+          {total > 0 && <span className={`${badge} bg-white/10 text-white/60`}>{index} / {total}</span>}
+          {autoAdvance && <span className={`${badge} bg-accent/30 text-white/85`}>Auto</span>}
+          {shuffle && <span className={`${badge} bg-accent/30 text-white/85`}>Shuffle</span>}
+          {frozen && <span className={`${badge} bg-sky-500/30 text-white/85`}>Frozen</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/visualizer/VisualizerTransport.test.tsx
+++ b/src/components/visualizer/VisualizerTransport.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import VisualizerTransport from './VisualizerTransport';
+import { usePlayerStore } from '../../stores/playerStore';
+import type { Song } from '../../types/subsonic';
+
+// Mock PlaybackManager so the component's getVolume()/seek()/volume calls never
+// load the real PlaybackManager → SubsonicClient chain (which can resolve after
+// Vitest teardown). Same rationale as playerStore.test.ts.
+const setVolume = vi.fn();
+const toggleMute = vi.fn();
+const seek = vi.fn();
+vi.mock('../../audio/PlaybackManager', () => ({
+  getPlaybackManager: () => ({
+    getVolume: () => 1,
+    setVolume,
+    toggleMute,
+    seek,
+    pauseRadio: () => {},
+    resumeRadio: () => {},
+  }),
+}));
+
+// Stub the heavy children — they pull in canvas / network / IntersectionObserver
+// not relevant to the transport's own logic, and are covered elsewhere.
+vi.mock('../common/CoverArt', () => ({ default: () => <div data-testid="cover" /> }));
+vi.mock('../player/WaveformSeekbar', () => ({ default: () => <div data-testid="seekbar" /> }));
+
+const makeSong = (id: string, title = `Song ${id}`): Song => ({
+  id,
+  title,
+  artist: `Artist ${id}`,
+  album: 'Test Album',
+  duration: 180,
+});
+
+beforeEach(() => {
+  setVolume.mockClear();
+  toggleMute.mockClear();
+  seek.mockClear();
+  usePlayerStore.setState({
+    queue: [],
+    currentIndex: -1,
+    currentSong: null,
+    isPlaying: false,
+    positionMs: 0,
+    durationMs: 0,
+    radioMode: null,
+    radioPlaying: false,
+    repeatMode: 'off',
+    shuffleEnabled: false,
+    shuffleOrder: [],
+  });
+});
+
+describe('VisualizerTransport', () => {
+  it('renders nothing when there is no current song or radio', () => {
+    const { container } = render(<VisualizerTransport onInteract={() => {}} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the current track title and artist', () => {
+    const song = makeSong('1', 'Song One');
+    usePlayerStore.setState({ queue: [song], currentIndex: 0, currentSong: song });
+    render(<VisualizerTransport onInteract={() => {}} />);
+    expect(screen.getByText('Song One')).toBeInTheDocument();
+    expect(screen.getByText('Artist 1')).toBeInTheDocument();
+  });
+
+  it('toggles play state and fires onInteract on play/pause (reusing the store action)', () => {
+    const song = makeSong('1', 'One');
+    usePlayerStore.setState({ queue: [song], currentIndex: 0, currentSong: song, isPlaying: false });
+    const onInteract = vi.fn();
+    render(<VisualizerTransport onInteract={onInteract} />);
+    fireEvent.click(screen.getByLabelText('Play'));
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+    // Fires from the button handler and again as the click bubbles to the
+    // wrapper (which wakes the overlay) — both wake the timer, which is fine.
+    expect(onInteract).toHaveBeenCalled();
+  });
+
+  it('advances to the next track via the existing store action', () => {
+    const queue = [makeSong('1', 'One'), makeSong('2', 'Two')];
+    usePlayerStore.setState({ queue, currentIndex: 0, currentSong: queue[0] });
+    render(<VisualizerTransport onInteract={() => {}} />);
+    fireEvent.click(screen.getByLabelText('Next track'));
+    expect(usePlayerStore.getState().currentSong?.title).toBe('Two');
+  });
+
+  it('goes to the previous track via the existing store action', () => {
+    const queue = [makeSong('1', 'One'), makeSong('2', 'Two')];
+    usePlayerStore.setState({ queue, currentIndex: 1, currentSong: queue[1], positionMs: 0 });
+    render(<VisualizerTransport onInteract={() => {}} />);
+    fireEvent.click(screen.getByLabelText('Previous track'));
+    expect(usePlayerStore.getState().currentSong?.title).toBe('One');
+  });
+
+  it('mutes via the existing PlaybackManager API', () => {
+    const song = makeSong('1', 'One');
+    usePlayerStore.setState({ queue: [song], currentIndex: 0, currentSong: song });
+    render(<VisualizerTransport onInteract={() => {}} />);
+    fireEvent.click(screen.getByLabelText('Mute'));
+    expect(toggleMute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/visualizer/VisualizerTransport.tsx
+++ b/src/components/visualizer/VisualizerTransport.tsx
@@ -1,0 +1,155 @@
+import { useState, useCallback } from 'react';
+import { usePlayerStore } from '../../stores/playerStore';
+import { getPlaybackManager } from '../../audio/PlaybackManager';
+import CoverArt from '../common/CoverArt';
+import WaveformSeekbar from '../player/WaveformSeekbar';
+
+interface VisualizerTransportProps {
+  /** Called on any interaction so the auto-hiding overlay timer resets. */
+  onInteract: () => void;
+}
+
+/**
+ * Compact now-playing transport rendered inside the visualizer overlay.
+ *
+ * Reuses existing playback state/logic (no duplication): playerStore for state
+ * and next/previous/togglePlay, PlaybackManager for seek/volume, and the shared
+ * CoverArt + WaveformSeekbar components (same seek idiom as PopOutPlayer).
+ *
+ * Click/tap only — no keyboard shortcuts (the document-level shortcuts in
+ * usePlayback already cover playback). Stops event propagation in the bubble
+ * phase so interacting here never triggers the canvas click/double-click
+ * (overlay timer / random preset); children still handle their own clicks first.
+ */
+export default function VisualizerTransport({ onInteract }: VisualizerTransportProps) {
+  const {
+    currentSong, isPlaying, positionMs, durationMs,
+    togglePlay, next, previous, radioMode, radioPlaying,
+  } = usePlayerStore();
+  const [volume, setVolume] = useState(() => Math.round(getPlaybackManager().getVolume() * 100));
+
+  const isRadio = !!radioMode;
+  const title = isRadio ? radioMode.stationName : currentSong?.title;
+  const subtitle = isRadio ? 'Radio' : currentSong?.artist;
+  const coverArt = isRadio ? radioMode.coverArt : currentSong?.coverArt;
+  const playing = isRadio ? radioPlaying : isPlaying;
+
+  const handleTogglePlay = useCallback(() => {
+    if (isRadio) {
+      const pm = getPlaybackManager();
+      if (radioPlaying) pm.pauseRadio(); else pm.resumeRadio();
+      usePlayerStore.setState({ radioPlaying: !radioPlaying });
+    } else {
+      togglePlay();
+    }
+    onInteract();
+  }, [isRadio, radioPlaying, togglePlay, onInteract]);
+
+  const handlePrev = useCallback(() => { previous(); onInteract(); }, [previous, onInteract]);
+  const handleNext = useCallback(() => { next(); onInteract(); }, [next, onInteract]);
+
+  const handleVolumeChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = Number(e.target.value);
+    setVolume(v);
+    getPlaybackManager().setVolume(v / 100);
+    onInteract();
+  }, [onInteract]);
+
+  const handleMute = useCallback(() => {
+    const pm = getPlaybackManager();
+    pm.toggleMute();
+    setVolume(Math.round(pm.getVolume() * 100));
+    onInteract();
+  }, [onInteract]);
+
+  // Nothing playing → render nothing. The smoke test loads with no playback, so
+  // this path must never throw or log.
+  if (!currentSong && !radioMode) return null;
+
+  const btn = 'flex h-11 w-11 items-center justify-center rounded-full text-white/80 transition-colors hover:bg-white/10 hover:text-white';
+
+  return (
+    <div
+      className="pointer-events-auto absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent px-3 pt-6 pb-3"
+      onClick={(e) => { e.stopPropagation(); onInteract(); }}
+      onDoubleClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => { e.stopPropagation(); onInteract(); }}
+      onTouchStart={(e) => { e.stopPropagation(); onInteract(); }}
+    >
+      <div className="mx-auto flex max-w-3xl items-center gap-3">
+        <CoverArt coverArt={coverArt} size={44} className="shrink-0 rounded-md" />
+
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-white">{title || 'Unknown'}</p>
+          {subtitle && <p className="truncate text-xs text-white/60">{subtitle}</p>}
+        </div>
+
+        <div className="flex items-center gap-1">
+          {!isRadio && (
+            <button onClick={handlePrev} className={btn} aria-label="Previous track">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5">
+                <path d="M6 6h2v12H6V6zm3.5 6l8.5 6V6l-8.5 6z" />
+              </svg>
+            </button>
+          )}
+          <button onClick={handleTogglePlay} className={`${btn} bg-white/10`} aria-label={playing ? 'Pause' : 'Play'}>
+            {playing ? (
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5">
+                <path d="M6 4h4v16H6V4zm8 0h4v16h-4V4z" />
+              </svg>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="ml-0.5 h-5 w-5">
+                <path d="M8 5v14l11-7L8 5z" />
+              </svg>
+            )}
+          </button>
+          {!isRadio && (
+            <button onClick={handleNext} className={btn} aria-label="Next track">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5">
+                <path d="M16 6h2v12h-2V6zM4 18l8.5-6L4 6v12z" />
+              </svg>
+            </button>
+          )}
+        </div>
+
+        {/* Volume — desktop only; mobile relies on hardware volume. */}
+        <div className="hidden items-center gap-1 sm:flex">
+          <button onClick={handleMute} className={btn} aria-label={volume === 0 ? 'Unmute' : 'Mute'}>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="h-5 w-5">
+              {volume === 0 ? (
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 6L7.5 9.5H4v5h3.5L12 18V6zM16 9l4 4m0-4l-4 4" />
+              ) : (
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.536 8.464a5 5 0 010 7.072M12 6L7.5 9.5H4v5h3.5L12 18V6z" />
+              )}
+            </svg>
+          </button>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={volume}
+            onChange={handleVolumeChange}
+            aria-label="Volume"
+            className="h-1 w-20 cursor-pointer appearance-none rounded-full bg-white/20 accent-accent [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white"
+          />
+        </div>
+      </div>
+
+      {/* Seekbar — songs only (radio has no scrubbable duration). */}
+      {!isRadio && (
+        <div className="mx-auto mt-1 max-w-3xl" style={{ height: 28 }}>
+          <WaveformSeekbar
+            songId={currentSong?.id}
+            progress={durationMs > 0 ? positionMs / durationMs : 0}
+            onSeek={(p) => {
+              const ms = Math.round(p * durationMs);
+              getPlaybackManager().seek(ms);
+              usePlayerStore.getState().setPosition(ms);
+              onInteract();
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -21,6 +21,7 @@ export default function SettingsScreen() {
     visualizerAutoAdvanceInterval, setVisualizerAutoAdvanceInterval,
     visualizerShuffle, setVisualizerShuffle,
     visualizerShowTransport, setVisualizerShowTransport,
+    visualizerTransitionPolish, setVisualizerTransitionPolish,
   } = useUIStore();
   const eqEnabled = useEQStore((s) => s.enabled);
 
@@ -390,6 +391,30 @@ export default function SettingsScreen() {
                     <span
                       className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
                         visualizerShowTransport ? 'translate-x-5' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
+              </div>
+
+              {/* Transition polish */}
+              <div className="border-t border-border pt-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <span className="text-sm text-text-primary">Transition polish</span>
+                    <p className="text-xs text-text-muted">Subtle vignette dip when a preset changes (still a hard cut). Suppressed when Reduce Motion is on</p>
+                  </div>
+                  <button
+                    role="switch"
+                    aria-checked={visualizerTransitionPolish}
+                    onClick={() => setVisualizerTransitionPolish(!visualizerTransitionPolish)}
+                    className={`relative h-6 w-11 rounded-full transition-colors ${
+                      visualizerTransitionPolish ? 'bg-accent' : 'bg-bg-tertiary'
+                    }`}
+                  >
+                    <span
+                      className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                        visualizerTransitionPolish ? 'translate-x-5' : 'translate-x-0'
                       }`}
                     />
                   </button>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -20,6 +20,7 @@ export default function SettingsScreen() {
     visualizerAutoAdvance, setVisualizerAutoAdvance,
     visualizerAutoAdvanceInterval, setVisualizerAutoAdvanceInterval,
     visualizerShuffle, setVisualizerShuffle,
+    visualizerShowTransport, setVisualizerShowTransport,
   } = useUIStore();
   const eqEnabled = useEQStore((s) => s.enabled);
 
@@ -365,6 +366,30 @@ export default function SettingsScreen() {
                     <span
                       className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
                         visualizerShuffle ? 'translate-x-5' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
+              </div>
+
+              {/* Show playback controls */}
+              <div className="border-t border-border pt-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <span className="text-sm text-text-primary">Show playback controls</span>
+                    <p className="text-xs text-text-muted">Show now-playing transport (play, skip, seek) in the visualizer overlay</p>
+                  </div>
+                  <button
+                    role="switch"
+                    aria-checked={visualizerShowTransport}
+                    onClick={() => setVisualizerShowTransport(!visualizerShowTransport)}
+                    className={`relative h-6 w-11 rounded-full transition-colors ${
+                      visualizerShowTransport ? 'bg-accent' : 'bg-bg-tertiary'
+                    }`}
+                  >
+                    <span
+                      className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                        visualizerShowTransport ? 'translate-x-5' : 'translate-x-0'
                       }`}
                     />
                   </button>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -22,6 +22,7 @@ export default function SettingsScreen() {
     visualizerShuffle, setVisualizerShuffle,
     visualizerShowTransport, setVisualizerShowTransport,
     visualizerTransitionPolish, setVisualizerTransitionPolish,
+    visualizerParticles, setVisualizerParticles,
   } = useUIStore();
   const eqEnabled = useEQStore((s) => s.enabled);
 
@@ -415,6 +416,30 @@ export default function SettingsScreen() {
                     <span
                       className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
                         visualizerTransitionPolish ? 'translate-x-5' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
+              </div>
+
+              {/* Particle layer */}
+              <div className="border-t border-border pt-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <span className="text-sm text-text-primary">Particle effects</span>
+                    <p className="text-xs text-text-muted">Subtle audio-reactive particle layer over the visualizer. Suppressed when Reduce Motion is on</p>
+                  </div>
+                  <button
+                    role="switch"
+                    aria-checked={visualizerParticles}
+                    onClick={() => setVisualizerParticles(!visualizerParticles)}
+                    className={`relative h-6 w-11 rounded-full transition-colors ${
+                      visualizerParticles ? 'bg-accent' : 'bg-bg-tertiary'
+                    }`}
+                  >
+                    <span
+                      className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                        visualizerParticles ? 'translate-x-5' : 'translate-x-0'
                       }`}
                     />
                   </button>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -598,7 +598,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.2</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.3</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -6,6 +6,7 @@ import { usePlayerStore } from '../stores/playerStore';
 import { usePresetStore } from '../stores/presetStore';
 import VisualizerTransport from '../components/visualizer/VisualizerTransport';
 import VisualizerHud from '../components/visualizer/VisualizerHud';
+import ParticleOverlay from '../components/visualizer/ParticleOverlay';
 import { useMediaQuery } from '../hooks/useMediaQuery';
 import type { PresetIndexEntry } from '../types/presets';
 
@@ -220,6 +221,7 @@ export default function VisualizerScreen() {
     visualizerShuffle, setVisualizerShuffle,
     visualizerShowTransport,
     visualizerTransitionPolish,
+    visualizerParticles,
     reduceMotion,
     keyboardShortcutsEnabled,
   } = useUIStore();
@@ -904,6 +906,10 @@ export default function VisualizerScreen() {
           <p className="text-lg text-white/60">Loading Milkdrop...</p>
         </div>
       )}
+
+      {/* Optional particle layer — above the engine canvases, below the
+          controls/HUD. Opt-in and force-suppressed under reduced motion. */}
+      {visualizerParticles && !motionReduced && <ParticleOverlay />}
 
       {/* Overlay */}
       <div

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -5,6 +5,8 @@ import { useUIStore } from '../stores/uiStore';
 import { usePlayerStore } from '../stores/playerStore';
 import { usePresetStore } from '../stores/presetStore';
 import VisualizerTransport from '../components/visualizer/VisualizerTransport';
+import VisualizerHud from '../components/visualizer/VisualizerHud';
+import { useMediaQuery } from '../hooks/useMediaQuery';
 import type { PresetIndexEntry } from '../types/presets';
 
 // projectM preset category that is excluded from normal selection: these are
@@ -217,8 +219,15 @@ export default function VisualizerScreen() {
     visualizerAutoAdvanceInterval, setVisualizerAutoAdvanceInterval,
     visualizerShuffle, setVisualizerShuffle,
     visualizerShowTransport,
+    visualizerTransitionPolish,
+    reduceMotion,
     keyboardShortcutsEnabled,
   } = useUIStore();
+
+  // Motion safety: suppress the transition polish under either the in-app
+  // reduce-motion setting or the OS prefers-reduced-motion media query.
+  const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+  const motionReduced = reduceMotion || prefersReducedMotion;
 
   // Subscribed only to decide whether the in-overlay transport renders (so the
   // bottom control bar / FPS overlay can shift up to make room for it).
@@ -236,6 +245,11 @@ export default function VisualizerScreen() {
   const [milkdropReady, setMilkdropReady] = useState(false);
   const [showOverlay, setShowOverlay] = useState(true);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  // Transient toast showing the preset name when it changes.
+  const [presetToast, setPresetToast] = useState<string | null>(null); // controls visibility
+  const [toastText, setToastText] = useState(''); // retained during the toast's fade-out
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const vignetteRef = useRef<HTMLDivElement>(null);
   // Which Milkdrop engine is active: 'projectm' (WebGPU) or 'butterchurn'
   // (fallback), decided when milkdrop mode activates.
   const [milkdropEngine, setMilkdropEngine] = useState<'projectm' | 'butterchurn' | null>(null);
@@ -809,9 +823,36 @@ export default function VisualizerScreen() {
   const displayPresetName = mode === 'shader'
     ? currentPreset.name
     : (milkdropPresetNames[milkdropPresetIndex] || 'Loading...');
-  const hudInfo = mode === 'milkdrop' && milkdropEngine
-    ? `${milkdropEngine === 'projectm' ? 'projectM' : 'butterchurn'} · ${milkdropPresetIndex + 1}/${totalPresets || '…'}`
-    : null;
+
+  // On preset change: show a brief name toast, and (when enabled and motion is
+  // not reduced) pulse a subtle DOM/CSS vignette over the still-hard-cut switch.
+  // The actual preset switch is unchanged — this is purely cosmetic overlay.
+  const prevPresetNameRef = useRef<string | null>(null);
+  useEffect(() => {
+    const name = displayPresetName;
+    const prev = prevPresetNameRef.current;
+    prevPresetNameRef.current = name;
+    // Skip the initial mount and the transient "Loading..." placeholder.
+    if (prev === null || !name || name === 'Loading...' || name === prev) return;
+
+    setToastText(name);
+    setPresetToast(name);
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    toastTimerRef.current = setTimeout(() => setPresetToast(null), 1800);
+
+    if (visualizerTransitionPolish && !motionReduced) {
+      const el = vignetteRef.current;
+      if (el && typeof el.animate === 'function') {
+        // A short darken-edges pulse (0 → subtle → 0). No white flash.
+        el.animate(
+          [{ opacity: 0 }, { opacity: 0.55, offset: 0.35 }, { opacity: 0 }],
+          { duration: 260, easing: 'ease-out' },
+        );
+      }
+    }
+  }, [displayPresetName, visualizerTransitionPolish, motionReduced]);
+
+  useEffect(() => () => { if (toastTimerRef.current) clearTimeout(toastTimerRef.current); }, []);
 
   const ctrlBtn = (on: boolean, disabled = false) =>
     `rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
@@ -886,17 +927,16 @@ export default function VisualizerScreen() {
             </svg>
           </button>
 
-          {/* Preset name + HUD info (engine · index/total · status) */}
-          <div className="flex max-w-[55%] flex-col items-center">
-            <span className="truncate text-sm font-medium text-white/80">
-              {displayPresetName}
-            </span>
-            {hudInfo && (
-              <span className="mt-0.5 text-[10px] font-medium tracking-wide text-white/40">
-                {hudInfo}{visualizerAutoAdvance ? ' · AUTO' : ''}{visualizerShuffle ? ' · SHUF' : ''}{frozen ? ' · FROZEN' : ''}
-              </span>
-            )}
-          </div>
+          {/* Preset name + status badges (engine · index/total · auto/shuffle/frozen) */}
+          <VisualizerHud
+            presetName={displayPresetName}
+            engine={mode === 'milkdrop' ? milkdropEngine : null}
+            index={milkdropPresetIndex + 1}
+            total={totalPresets}
+            autoAdvance={visualizerAutoAdvance}
+            shuffle={visualizerShuffle}
+            frozen={frozen}
+          />
 
           {/* Right controls: fullscreen toggle (when supported) + mode toggle */}
           <div className="flex items-center gap-2">
@@ -997,6 +1037,25 @@ export default function VisualizerScreen() {
           {fps} fps · {milkdropEngine === 'projectm' ? 'projectM/WebGPU' : mode === 'milkdrop' ? 'butterchurn/WebGL' : 'shader/WebGL'}
         </div>
       )}
+
+      {/* Transition polish: subtle vignette pulse on preset change (opacity
+          animated via WAAPI only when enabled + motion not reduced). Hard cut
+          underneath is unchanged. */}
+      <div
+        ref={vignetteRef}
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-0"
+        style={{ background: 'radial-gradient(ellipse at center, transparent 55%, rgba(0,0,0,0.7) 100%)' }}
+      />
+
+      {/* Preset-name toast — brief, independent of the auto-hiding overlay */}
+      <div
+        className={`pointer-events-none absolute top-[22%] left-1/2 -translate-x-1/2 rounded-full bg-black/60 px-4 py-1.5 text-sm font-medium text-white/90 backdrop-blur-sm transition-opacity ${
+          motionReduced ? '' : 'duration-300'
+        } ${presetToast ? 'opacity-100' : 'opacity-0'}`}
+      >
+        {toastText}
+      </div>
     </div>
   );
 }

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -2,7 +2,9 @@ import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getPlaybackManager } from '../audio/PlaybackManager';
 import { useUIStore } from '../stores/uiStore';
+import { usePlayerStore } from '../stores/playerStore';
 import { usePresetStore } from '../stores/presetStore';
+import VisualizerTransport from '../components/visualizer/VisualizerTransport';
 import type { PresetIndexEntry } from '../types/presets';
 
 // projectM preset category that is excluded from normal selection: these are
@@ -214,8 +216,15 @@ export default function VisualizerScreen() {
     visualizerAutoAdvance, setVisualizerAutoAdvance,
     visualizerAutoAdvanceInterval, setVisualizerAutoAdvanceInterval,
     visualizerShuffle, setVisualizerShuffle,
+    visualizerShowTransport,
     keyboardShortcutsEnabled,
   } = useUIStore();
+
+  // Subscribed only to decide whether the in-overlay transport renders (so the
+  // bottom control bar / FPS overlay can shift up to make room for it).
+  const transportSong = usePlayerStore((s) => s.currentSong);
+  const transportRadio = usePlayerStore((s) => s.radioMode);
+  const transportVisible = visualizerShowTransport && (!!transportSong || !!transportRadio);
 
   const [mode, setMode] = useState<'shader' | 'milkdrop'>('shader');
   const [frozen, setFrozen] = useState(false);
@@ -957,9 +966,9 @@ export default function VisualizerScreen() {
           </>
         )}
 
-        {/* Milkdrop control bar */}
+        {/* Milkdrop control bar — shifts up when the transport occupies the bottom */}
         {mode === 'milkdrop' && milkdropReady && (
-          <div className="pointer-events-auto absolute bottom-6 left-1/2 flex -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-full bg-black/60 px-3 py-2">
+          <div className={`pointer-events-auto absolute left-1/2 flex -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-full bg-black/60 px-3 py-2 ${transportVisible ? 'bottom-28' : 'bottom-6'}`}>
             <button onClick={(e) => { e.stopPropagation(); toggleFreeze(); }} title="Freeze / unfreeze (K)" className={ctrlBtn(frozen)}>
               {frozen ? '▶ Resume' : '⏸ Freeze'}
             </button>
@@ -977,11 +986,14 @@ export default function VisualizerScreen() {
             </button>
           </div>
         )}
+
+        {/* In-visualizer playback transport (opt-in; self-hides with no song) */}
+        {visualizerShowTransport && <VisualizerTransport onInteract={resetOverlayTimer} />}
       </div>
 
       {/* FPS overlay — persists regardless of the auto-hiding controls */}
       {showFps && (
-        <div className="pointer-events-none absolute bottom-2 left-2 rounded bg-black/60 px-2 py-1 font-mono text-xs text-green-400">
+        <div className={`pointer-events-none absolute left-2 rounded bg-black/60 px-2 py-1 font-mono text-xs text-green-400 ${transportVisible ? 'bottom-24' : 'bottom-2'}`}>
           {fps} fps · {milkdropEngine === 'projectm' ? 'projectM/WebGPU' : mode === 'milkdrop' ? 'butterchurn/WebGL' : 'shader/WebGL'}
         </div>
       )}

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getPlaybackManager } from '../audio/PlaybackManager';
 import { useUIStore } from '../stores/uiStore';
@@ -180,6 +180,7 @@ export default function VisualizerScreen() {
   const navigate = useNavigate();
   const { epilepsyWarningDismissed, setEpilepsyWarningDismissed } = useUIStore();
   const [showWarning, setShowWarning] = useState(!epilepsyWarningDismissed);
+  const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const milkdropCanvasRef = useRef<HTMLCanvasElement>(null);
   const glRef = useRef<WebGLRenderingContext | null>(null);
@@ -225,6 +226,7 @@ export default function VisualizerScreen() {
   const [milkdropPresetNames, setMilkdropPresetNames] = useState<string[]>([]);
   const [milkdropReady, setMilkdropReady] = useState(false);
   const [showOverlay, setShowOverlay] = useState(true);
+  const [isFullscreen, setIsFullscreen] = useState(false);
   // Which Milkdrop engine is active: 'projectm' (WebGPU) or 'butterchurn'
   // (fallback), decided when milkdrop mode activates.
   const [milkdropEngine, setMilkdropEngine] = useState<'projectm' | 'butterchurn' | null>(null);
@@ -238,6 +240,53 @@ export default function VisualizerScreen() {
     if (overlayTimeoutRef.current) clearTimeout(overlayTimeoutRef.current);
     overlayTimeoutRef.current = setTimeout(() => setShowOverlay(false), 4000);
   }, []);
+
+  // Fullscreen support is feature-detected once. iOS Safari (iPhone) only allows
+  // fullscreen on <video>, not arbitrary elements, so neither flag is set there
+  // and the toggle button is hidden entirely. Older WebKit uses the webkit prefix.
+  const fullscreenSupported = useMemo(() => {
+    if (typeof document === 'undefined') return false;
+    const doc = document as Document & { webkitFullscreenEnabled?: boolean };
+    return !!(doc.fullscreenEnabled || doc.webkitFullscreenEnabled);
+  }, []);
+
+  // Toggle fullscreen on the visualizer root container. Click-only (no shortcut),
+  // never auto-entered. requestFullscreen needs the click's user gesture; we
+  // swallow any rejection so it can never surface as a console error.
+  const toggleFullscreen = useCallback(() => {
+    const el = containerRef.current as
+      | (HTMLDivElement & { webkitRequestFullscreen?: () => void | Promise<void> })
+      | null;
+    if (!el) return;
+    const doc = document as Document & {
+      webkitFullscreenElement?: Element | null;
+      webkitExitFullscreen?: () => void | Promise<void>;
+    };
+    const active = document.fullscreenElement || doc.webkitFullscreenElement;
+    const run = active
+      ? (document.exitFullscreen ?? doc.webkitExitFullscreen)?.call(document)
+      : (el.requestFullscreen ?? el.webkitRequestFullscreen)?.call(el);
+    if (run && typeof (run as Promise<void>).catch === 'function') {
+      (run as Promise<void>).catch(() => { /* user gesture / unsupported — ignore */ });
+    }
+    resetOverlayTimer();
+  }, [resetOverlayTimer]);
+
+  // Keep the button state in sync with the actual fullscreen state, including
+  // when the user exits via ESC or the browser chrome.
+  useEffect(() => {
+    if (!fullscreenSupported) return;
+    const onChange = () => {
+      const doc = document as Document & { webkitFullscreenElement?: Element | null };
+      setIsFullscreen(!!(document.fullscreenElement || doc.webkitFullscreenElement));
+    };
+    document.addEventListener('fullscreenchange', onChange);
+    document.addEventListener('webkitfullscreenchange', onChange);
+    return () => {
+      document.removeEventListener('fullscreenchange', onChange);
+      document.removeEventListener('webkitfullscreenchange', onChange);
+    };
+  }, [fullscreenSupported]);
 
   // Keep loop-read refs in sync with state.
   useEffect(() => { frozenRef.current = frozen; }, [frozen]);
@@ -762,6 +811,7 @@ export default function VisualizerScreen() {
 
   return (
     <div
+      ref={containerRef}
       className="relative h-screen w-screen bg-black"
       onClick={handleCanvasClick}
       onDoubleClick={handleCanvasDoubleClick}
@@ -839,17 +889,42 @@ export default function VisualizerScreen() {
             )}
           </div>
 
-          {/* Mode toggle */}
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              setMode((m) => (m === 'shader' ? 'milkdrop' : 'shader'));
-              resetOverlayTimer();
-            }}
-            className="rounded-full bg-white/10 px-3 py-1.5 text-xs font-medium text-white/80 transition-colors hover:bg-white/20"
-          >
-            {mode === 'shader' ? 'Milkdrop' : 'Shader'}
-          </button>
+          {/* Right controls: fullscreen toggle (when supported) + mode toggle */}
+          <div className="flex items-center gap-2">
+            {fullscreenSupported && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleFullscreen();
+                }}
+                className="flex h-10 w-10 items-center justify-center rounded-full text-white/80 transition-colors hover:bg-white/10 hover:text-white"
+                aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+                title={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+              >
+                {isFullscreen ? (
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="h-5 w-5">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 9V4.5M9 9H4.5M9 9 3.75 3.75M9 15v4.5M9 15H4.5M9 15l-5.25 5.25M15 9h4.5M15 9V4.5M15 9l5.25-5.25M15 15h4.5M15 15v4.5m0-4.5 5.25 5.25" />
+                  </svg>
+                ) : (
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="h-5 w-5">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
+                  </svg>
+                )}
+              </button>
+            )}
+
+            {/* Mode toggle */}
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setMode((m) => (m === 'shader' ? 'milkdrop' : 'shader'));
+                resetOverlayTimer();
+              }}
+              className="rounded-full bg-white/10 px-3 py-1.5 text-xs font-medium text-white/80 transition-colors hover:bg-white/20"
+            >
+              {mode === 'shader' ? 'Milkdrop' : 'Shader'}
+            </button>
+          </div>
         </div>
 
         {/* Arrow navigation */}

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -16,6 +16,7 @@ const VIS_AUTO_ADVANCE_KEY = 'vibrdrome_visualizer_auto_advance';
 const VIS_AUTO_ADVANCE_INTERVAL_KEY = 'vibrdrome_visualizer_auto_advance_interval';
 const VIS_SHUFFLE_KEY = 'vibrdrome_visualizer_shuffle';
 const VIS_SHOW_TRANSPORT_KEY = 'vibrdrome_visualizer_show_transport';
+const VIS_TRANSITION_POLISH_KEY = 'vibrdrome_visualizer_transition_polish';
 const DEFAULT_ACCENT = '#8b5cf6';
 
 type Theme = 'system' | 'dark' | 'light' | 'apple' | 'apple-dark' | 'retro' | 'terminal' | 'midnight' | 'sunset';
@@ -68,6 +69,8 @@ interface UIState {
   setVisualizerShuffle: (value: boolean) => void;
   visualizerShowTransport: boolean;
   setVisualizerShowTransport: (value: boolean) => void;
+  visualizerTransitionPolish: boolean;
+  setVisualizerTransitionPolish: (value: boolean) => void;
 
   castConnected: boolean;
   setCastConnected: (connected: boolean) => void;
@@ -230,6 +233,13 @@ export const useUIStore = create<UIState>((set) => ({
   setVisualizerShowTransport: (value) => {
     try { localStorage.setItem(VIS_SHOW_TRANSPORT_KEY, String(value)); } catch { /* ignore */ }
     set({ visualizerShowTransport: value });
+  },
+  // Subtle DOM/CSS vignette dip around the (still hard-cut) preset switch.
+  // Default off; always suppressed under reduced motion. No engine changes.
+  visualizerTransitionPolish: loadBool(VIS_TRANSITION_POLISH_KEY, false),
+  setVisualizerTransitionPolish: (value) => {
+    try { localStorage.setItem(VIS_TRANSITION_POLISH_KEY, String(value)); } catch { /* ignore */ }
+    set({ visualizerTransitionPolish: value });
   },
 
   castConnected: false,

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -17,6 +17,7 @@ const VIS_AUTO_ADVANCE_INTERVAL_KEY = 'vibrdrome_visualizer_auto_advance_interva
 const VIS_SHUFFLE_KEY = 'vibrdrome_visualizer_shuffle';
 const VIS_SHOW_TRANSPORT_KEY = 'vibrdrome_visualizer_show_transport';
 const VIS_TRANSITION_POLISH_KEY = 'vibrdrome_visualizer_transition_polish';
+const VIS_PARTICLES_KEY = 'vibrdrome_visualizer_particles';
 const DEFAULT_ACCENT = '#8b5cf6';
 
 type Theme = 'system' | 'dark' | 'light' | 'apple' | 'apple-dark' | 'retro' | 'terminal' | 'midnight' | 'sunset';
@@ -71,6 +72,8 @@ interface UIState {
   setVisualizerShowTransport: (value: boolean) => void;
   visualizerTransitionPolish: boolean;
   setVisualizerTransitionPolish: (value: boolean) => void;
+  visualizerParticles: boolean;
+  setVisualizerParticles: (value: boolean) => void;
 
   castConnected: boolean;
   setCastConnected: (connected: boolean) => void;
@@ -240,6 +243,13 @@ export const useUIStore = create<UIState>((set) => ({
   setVisualizerTransitionPolish: (value) => {
     try { localStorage.setItem(VIS_TRANSITION_POLISH_KEY, String(value)); } catch { /* ignore */ }
     set({ visualizerTransitionPolish: value });
+  },
+  // Optional 2D-canvas particle layer. Default off; force-suppressed under
+  // reduced motion by the consumer. No GL/WebGPU context involved.
+  visualizerParticles: loadBool(VIS_PARTICLES_KEY, false),
+  setVisualizerParticles: (value) => {
+    try { localStorage.setItem(VIS_PARTICLES_KEY, String(value)); } catch { /* ignore */ }
+    set({ visualizerParticles: value });
   },
 
   castConnected: false,

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -15,6 +15,7 @@ const VIS_FORCE_BUTTERCHURN_KEY = 'vibrdrome_visualizer_force_butterchurn';
 const VIS_AUTO_ADVANCE_KEY = 'vibrdrome_visualizer_auto_advance';
 const VIS_AUTO_ADVANCE_INTERVAL_KEY = 'vibrdrome_visualizer_auto_advance_interval';
 const VIS_SHUFFLE_KEY = 'vibrdrome_visualizer_shuffle';
+const VIS_SHOW_TRANSPORT_KEY = 'vibrdrome_visualizer_show_transport';
 const DEFAULT_ACCENT = '#8b5cf6';
 
 type Theme = 'system' | 'dark' | 'light' | 'apple' | 'apple-dark' | 'retro' | 'terminal' | 'midnight' | 'sunset';
@@ -65,6 +66,8 @@ interface UIState {
   setVisualizerAutoAdvanceInterval: (seconds: number) => void;
   visualizerShuffle: boolean;
   setVisualizerShuffle: (value: boolean) => void;
+  visualizerShowTransport: boolean;
+  setVisualizerShowTransport: (value: boolean) => void;
 
   castConnected: boolean;
   setCastConnected: (connected: boolean) => void;
@@ -220,6 +223,13 @@ export const useUIStore = create<UIState>((set) => ({
   setVisualizerShuffle: (value) => {
     try { localStorage.setItem(VIS_SHUFFLE_KEY, String(value)); } catch { /* ignore */ }
     set({ visualizerShuffle: value });
+  },
+  // Conservative default: off. The transport self-hides with no song, so this
+  // keeps existing behavior (and the smoke test) unchanged until opted in.
+  visualizerShowTransport: loadBool(VIS_SHOW_TRANSPORT_KEY, false),
+  setVisualizerShowTransport: (value) => {
+    try { localStorage.setItem(VIS_SHOW_TRANSPORT_KEY, String(value)); } catch { /* ignore */ }
+    set({ visualizerShowTransport: value });
   },
 
   castConnected: false,


### PR DESCRIPTION
## Release 1.9.0-beta.3

Promotes the merged visualizer polish pass from `develop` to production. Metadata version is `1.9.0-beta.3`.

### Included (app/UI-only)
- **Visualizer fullscreen toggle** — feature-detected, with WebKit fallbacks; hidden where the Fullscreen API is unsupported (e.g. iOS Safari).
- **Optional in-visualizer playback controls** (now-playing transport: cover, title/artist, play/pause, prev/next, seek, desktop volume). Default OFF.
- **Visualizer HUD / status-badge polish** (engine, position, auto/shuffle/frozen badges).
- **Preset-name toast** on preset change.
- **Optional reduced-motion-safe transition vignette** — a subtle DOM/CSS dip around the still-hard-cut preset switch. Default OFF.
- **Optional 2D-canvas particle overlay** — audio-reactive, capped, throttled. Default OFF.

### Not included / unchanged
- **No projectM engine / WASM behavior changes** — preset switching remains a hard cut.
- **No real crossfade or screenshot/readback transition work.**
- No dependency changes. No projectM-rs changes.

Particles and transition polish are opt-in and reduced-motion aware (suppressed under Reduce Motion or `prefers-reduced-motion: reduce`).

### Verification
develop is fully green (lint/test/build/`test:smoke`/docker/scan); 176 tests; `docker build` succeeds; production-preview smoke passes. Tag `v1.9.0-beta.3` + GitHub Release will follow once production render is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)