### PR TITLE
Quiet auto-advance and pin player controls

### DIFF
--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -23,6 +23,7 @@ export default function SettingsScreen() {
     visualizerShowTransport, setVisualizerShowTransport,
     visualizerTransitionPolish, setVisualizerTransitionPolish,
     visualizerParticles, setVisualizerParticles,
+    visualizerPinControls, setVisualizerPinControls,
   } = useUIStore();
   const eqEnabled = useEQStore((s) => s.enabled);
 
@@ -440,6 +441,30 @@ export default function SettingsScreen() {
                     <span
                       className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
                         visualizerParticles ? 'translate-x-5' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
+              </div>
+
+              {/* Keep player controls on screen */}
+              <div className="border-t border-border pt-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <span className="text-sm text-text-primary">Keep player controls on screen</span>
+                    <p className="text-xs text-text-muted">Pin the in-visualizer playback controls instead of letting them auto-hide</p>
+                  </div>
+                  <button
+                    role="switch"
+                    aria-checked={visualizerPinControls}
+                    onClick={() => setVisualizerPinControls(!visualizerPinControls)}
+                    className={`relative h-6 w-11 rounded-full transition-colors ${
+                      visualizerPinControls ? 'bg-accent' : 'bg-bg-tertiary'
+                    }`}
+                  >
+                    <span
+                      className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                        visualizerPinControls ? 'translate-x-5' : 'translate-x-0'
                       }`}
                     />
                   </button>

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -222,6 +222,7 @@ export default function VisualizerScreen() {
     visualizerShowTransport,
     visualizerTransitionPolish,
     visualizerParticles,
+    visualizerPinControls, setVisualizerPinControls,
     reduceMotion,
     keyboardShortcutsEnabled,
   } = useUIStore();
@@ -252,6 +253,9 @@ export default function VisualizerScreen() {
   const [toastText, setToastText] = useState(''); // retained during the toast's fade-out
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const vignetteRef = useRef<HTMLDivElement>(null);
+  // Set just before an auto-advance preset change so the toast + overlay stay
+  // silent for that change (the optional vignette still plays).
+  const suppressNextToastRef = useRef(false);
   // Which Milkdrop engine is active: 'projectm' (WebGPU) or 'butterchurn'
   // (fallback), decided when milkdrop mode activates.
   const [milkdropEngine, setMilkdropEngine] = useState<'projectm' | 'butterchurn' | null>(null);
@@ -773,14 +777,30 @@ export default function VisualizerScreen() {
     resetOverlayTimer();
   };
 
+  // Silent preset change driven by the auto-advance timer: changes the preset
+  // without waking the overlay or showing the toast (the vignette still plays).
+  // Uses the functional updater so it never reads a stale index from the interval.
+  const autoAdvance = () => {
+    suppressNextToastRef.current = true;
+    if (visualizerShuffle) {
+      setActiveIndex((i) => {
+        if (totalPresets <= 1) return i;
+        let next: number;
+        do {
+          next = Math.floor(Math.random() * totalPresets);
+        } while (next === i);
+        return next;
+      });
+    } else {
+      setActiveIndex((i) => (i + 1) % totalPresets);
+    }
+  };
+
   // Auto-advance: cycle presets on the configured interval while in Milkdrop.
   useEffect(() => {
     if (mode !== 'milkdrop' || !milkdropReady || !visualizerAutoAdvance) return;
     const ms = Math.max(1, visualizerAutoAdvanceInterval) * 1000;
-    const id = setInterval(() => {
-      if (visualizerShuffle) randomPreset();
-      else nextPreset();
-    }, ms);
+    const id = setInterval(autoAdvance, ms);
     return () => clearInterval(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, milkdropReady, visualizerAutoAdvance, visualizerAutoAdvanceInterval, visualizerShuffle]);
@@ -837,10 +857,16 @@ export default function VisualizerScreen() {
     // Skip the initial mount and the transient "Loading..." placeholder.
     if (prev === null || !name || name === 'Loading...' || name === prev) return;
 
-    setToastText(name);
-    setPresetToast(name);
-    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
-    toastTimerRef.current = setTimeout(() => setPresetToast(null), 1800);
+    // Auto-advance changes are silent: no toast (and the timer never woke the
+    // overlay). The vignette below still plays for smooth slideshow transitions.
+    const silent = suppressNextToastRef.current;
+    suppressNextToastRef.current = false;
+    if (!silent) {
+      setToastText(name);
+      setPresetToast(name);
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+      toastTimerRef.current = setTimeout(() => setPresetToast(null), 1800);
+    }
 
     if (visualizerTransitionPolish && !motionReduced) {
       const el = vignetteRef.current;
@@ -1030,12 +1056,27 @@ export default function VisualizerScreen() {
             <button onClick={(e) => { e.stopPropagation(); toggleFps(); }} title="FPS overlay (F)" className={ctrlBtn(showFps)}>
               FPS
             </button>
+            {visualizerShowTransport && (
+              <button onClick={(e) => { e.stopPropagation(); setVisualizerPinControls(!visualizerPinControls); resetOverlayTimer(); }} title="Keep player controls on screen" className={ctrlBtn(visualizerPinControls)}>
+                📌 Pin
+              </button>
+            )}
           </div>
         )}
-
-        {/* In-visualizer playback transport (opt-in; self-hides with no song) */}
-        {visualizerShowTransport && <VisualizerTransport onInteract={resetOverlayTimer} />}
       </div>
+
+      {/* In-visualizer playback transport (opt-in; self-hides with no song).
+          Lives outside the auto-hiding overlay so the Pin toggle can keep just
+          the player controls on screen while the rest of the HUD still fades. */}
+      {visualizerShowTransport && (
+        <div
+          className={`transition-opacity duration-500 ${
+            showOverlay || visualizerPinControls ? 'opacity-100' : 'pointer-events-none opacity-0'
+          }`}
+        >
+          <VisualizerTransport onInteract={resetOverlayTimer} />
+        </div>
+      )}
 
       {/* FPS overlay — persists regardless of the auto-hiding controls */}
       {showFps && (

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -18,6 +18,7 @@ const VIS_SHUFFLE_KEY = 'vibrdrome_visualizer_shuffle';
 const VIS_SHOW_TRANSPORT_KEY = 'vibrdrome_visualizer_show_transport';
 const VIS_TRANSITION_POLISH_KEY = 'vibrdrome_visualizer_transition_polish';
 const VIS_PARTICLES_KEY = 'vibrdrome_visualizer_particles';
+const VIS_PIN_CONTROLS_KEY = 'vibrdrome_visualizer_pin_controls';
 const DEFAULT_ACCENT = '#8b5cf6';
 
 type Theme = 'system' | 'dark' | 'light' | 'apple' | 'apple-dark' | 'retro' | 'terminal' | 'midnight' | 'sunset';
@@ -74,6 +75,8 @@ interface UIState {
   setVisualizerTransitionPolish: (value: boolean) => void;
   visualizerParticles: boolean;
   setVisualizerParticles: (value: boolean) => void;
+  visualizerPinControls: boolean;
+  setVisualizerPinControls: (value: boolean) => void;
 
   castConnected: boolean;
   setCastConnected: (connected: boolean) => void;
@@ -250,6 +253,13 @@ export const useUIStore = create<UIState>((set) => ({
   setVisualizerParticles: (value) => {
     try { localStorage.setItem(VIS_PARTICLES_KEY, String(value)); } catch { /* ignore */ }
     set({ visualizerParticles: value });
+  },
+  // Keep the in-visualizer player controls (transport) on screen instead of
+  // auto-hiding with the rest of the overlay. Default off.
+  visualizerPinControls: loadBool(VIS_PIN_CONTROLS_KEY, false),
+  setVisualizerPinControls: (value) => {
+    try { localStorage.setItem(VIS_PIN_CONTROLS_KEY, String(value)); } catch { /* ignore */ }
+    set({ visualizerPinControls: value });
   },
 
   castConnected: false,


### PR DESCRIPTION
## Summary

Two small visualizer UX fixes from real-device testing of 1.9.0-beta.3. App/UI-only.

### Quiet auto-advance
- Auto-advance now changes presets **without waking the overlay** (it no longer reuses the manual `resetOverlayTimer()` path).
- Auto-advance **suppresses the preset-name toast** (via a one-shot `suppressNextToastRef`).
- Manual `N` / `P` / double-click are unchanged — they still show the toast and overlay as before.
- The optional **transition vignette still runs** on auto-advance, so a hands-off slideshow keeps smooth transitions without UI chrome flashing.

### Pin player controls
- Adds `visualizerPinControls` setting, **default OFF**.
- The transport now lives outside the auto-hiding overlay; its visibility is `showOverlay || visualizerPinControls`, so when pinned the **player controls stay visible while the rest of the HUD/overlay still auto-hides**.
- Adds a **"📌 Pin"** button in the visualizer control bar (the HUD menu).
- Adds a matching **"Keep player controls on screen"** toggle in Settings → Visualizer (also reachable in shader mode).

### Not included
- No dependency changes. No release/version/tag metadata changes. No pmweb/preset/projectM-rs changes. No crossfade/readback work.

## Files changed (3)
- `src/screens/VisualizerScreen.tsx`
- `src/stores/uiStore.ts`
- `src/screens/SettingsScreen.tsx`

## Test plan

Local (all passing):
- `npm run lint` — clean
- `npm run test:run` — 176 passed / 19 files
- `npm run build` — succeeds
- `npm run test:smoke` — `root mounted: true · console errors: 0 · PASS`

Interactive verification (real Chromium against the production build, butterchurn initialized headlessly), 13/13: auto-advance changed the preset while the **overlay stayed hidden** and **no toast appeared**; manual `N` still toasts; pin OFF → transport auto-hides; pin ON → transport stays visible while the rest of the HUD hides; fullscreen still works; double-click still randomizes; no relevant console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)