### PR TITLE
Mark beta tags as GitHub prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,4 @@ jobs:
         with:
           body: ${{ steps.changelog.outputs.body }}
           generate_release_notes: false
+          prerelease: ${{ contains(github.ref_name, '-beta.') }}


### PR DESCRIPTION
## Summary

Beta tags currently publish as **full** GitHub releases because the release workflow (`softprops/action-gh-release@v3`) never sets the `prerelease` input, which defaults to false with no tag-name auto-detection. That's why `v1.9.0-beta.1/2/3` all published with `prerelease=false`.

This adds prerelease detection for tags containing `-beta.`.

### Change (one line, `.github/workflows/release.yml`)
```yaml
prerelease: ${{ contains(github.ref_name, '-beta.') }}
```

### Expected behavior
- `v1.9.0-beta.4` → `prerelease=true`
- `v1.9.0-beta.10` → `prerelease=true`
- `v1.9.0` → `prerelease=false`
- `v2.0.0` → `prerelease=false`

### Scope / safety
- Does **not** edit old releases (beta.1/2/3 stay as-is; the workflow only runs on new tag pushes).
- Does **not** change release notes (the `body`/changelog logic is untouched).
- Does **not** change app code or dependencies.
- Does **not** deploy production.
- Takes effect on **future beta tags** only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)