### PR TITLE
Prepare v1.9.0-beta.4 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.4] - 2026-06-20
+
+### Added
+- Optional projectM/WebGPU **frozen-frame preset crossfade** — fades the old preset out over the new one. Default off (hard-cut), with a Settings → Visualizer toggle; falls back silently to a hard cut on capture failure and is suppressed under Reduce Motion / `prefers-reduced-motion`.
+- **Pin visualizer player controls** — keep the in-visualizer playback controls on screen instead of auto-hiding (Settings + a control-bar toggle).
+
+### Changed
+- **Quiet auto-advance** — when auto-advance changes the visualizer preset, it no longer wakes the overlay or shows the preset-name toast (the optional transition vignette still plays).
+- Production dependency refresh (React, React DOM, React Router, Zustand, Tailwind Vite plugin, `@types/react`); **Vite intentionally remains pinned to `8.0.9`** and no other dependency policy changed.
+
+### Notes
+- Beta tags now publish as **GitHub prereleases** — effective once this reaches `master` (the first prerelease-flagged tag is `v1.9.0-beta.4`).
+- No projectM engine / WASM behavior changed; preset switching remains a hard cut by default.
+
 ## [1.9.0-beta.3] - 2026-06-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.3",
+  "version": "1.9.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.3",
+      "version": "1.9.0-beta.4",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.3",
+  "version": "1.9.0-beta.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.3</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.4</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">


### PR DESCRIPTION
## Summary

Release-prep metadata for **v1.9.0-beta.4** (no functional code changes). Bundles the four queued features for a beta cut.

### Version bump
- `package.json` + `package-lock.json` (root only): `1.9.0-beta.3` → `1.9.0-beta.4`
- `src/screens/SettingsScreen.tsx` About string: `v1.9.0-beta.3` → `v1.9.0-beta.4`
- `CHANGELOG.md`: new `[1.9.0-beta.4]` entry

### What beta.4 ships (already merged to develop)
- **#45** Quiet auto-advance (preset changes no longer wake the overlay/toast) + pinned visualizer player controls.
- **#26** Production dependency refresh (React/router/zustand/tailwind-plugin/@types/react) — **Vite intentionally still pinned to `8.0.9`**.
- **#46** Beta tags now publish as GitHub prereleases (effective once this reaches `master`; first prerelease-flagged tag is `v1.9.0-beta.4`).
- **#47** projectM frozen-frame preset crossfade — **default off**, hard-cut fallback, reduced-motion suppression.

### Scope / safety
- **No dependency changes** in this PR (only the root project version in the lockfile).
- **Vite remains pinned to `8.0.9`.**
- No `master` / tag / GitHub Release / deploy in this PR — those are later, separate steps.
- **PR #22 and PR #27 remain held** (deploy-action and Vite-bump risk respectively).

## Test plan

Local (all passing on this branch):
- `npm run lint` — clean
- `npm run test:run` — 186 passed / 20 files
- `npm run build` — succeeds
- `npm run test:smoke` — `root mounted · 0 console errors · PASS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)