### PR TITLE
Fix Docker libexpat CVE scan blocker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,10 @@ LABEL org.opencontainers.image.title="Vibrdrome Web" \
 
 # Pull in latest Alpine security patches so the image isn't pinned to whatever
 # nginx:alpine shipped with (e.g. CVE-2026-27135 in nghttp2-libs).
-RUN apk upgrade --no-cache
+# Explicitly ensure libexpat >= 2.8.1-r0 to clear CVE-2026-45186 (HIGH, DoS via
+# crafted XML) — the fixed package is in the Alpine 3.23 main repo. The explicit
+# line also busts stale CI build cache so the upgrade actually re-runs.
+RUN apk upgrade --no-cache && apk add --no-cache "libexpat>=2.8.1-r0"
 
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Summary

Clears the repo-wide Trivy `scan` failure caused by a base-image vulnerability — a **Docker-only** change.

- **CVE:** `CVE-2026-45186` (HIGH) — libexpat denial of service via crafted XML.
- **Current installed package:** `libexpat 2.7.5-r0` (in `nginx:alpine` → Alpine 3.23.4).
- **Required fixed package:** `2.8.1-r0`.

### Root cause
The fixed `libexpat 2.8.1-r0` **is** in the Alpine 3.23 *main* repo (`apk policy` confirms it), so the existing `RUN apk upgrade --no-cache` should clear it. CI kept reporting `2.7.5-r0` only because the scan job's Docker build is **GHA-cached** (`cache-from: type=gha`) — the `apk upgrade` layer was reused from before the fix was published, so the upgrade never re-ran.

### Remediation chosen (smallest Docker-only change)
```diff
-RUN apk upgrade --no-cache
+RUN apk upgrade --no-cache && apk add --no-cache "libexpat>=2.8.1-r0"
```
The explicit `apk add "libexpat>=2.8.1-r0"` **guarantees** the fixed package (and fails the build loudly if it were ever unavailable) and **busts the stale build cache** so the upgrade actually re-runs. No edge packages, no base-image swap, no `.trivyignore`.

### Local verification
- `docker build --no-cache` → final image ships **`libexpat-2.8.1-r0`** (Alpine 3.23.4).
- Local Trivy scan (same gate as CI: `--severity CRITICAL,HIGH --exit-code 1`) → **0 vulnerabilities, clean**.

### Scope
- **Only `Dockerfile` changed** (one `RUN` line + comment). No app code, no dependencies, no `package.json`/`package-lock.json`, no release/version metadata, no workflow changes.
- **Separate from PR #48** (the v1.9.0-beta.4 release-metadata PR) — that PR is untouched and remains blocked until this lands and its scan is re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)