### PR TITLE
Release v1.9.0-beta.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,4 @@ jobs:
         with:
           body: ${{ steps.changelog.outputs.body }}
           generate_release_notes: false
+          prerelease: ${{ contains(github.ref_name, '-beta.') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.4] - 2026-06-20
+
+### Added
+- Optional projectM/WebGPU **frozen-frame preset crossfade** — fades the old preset out over the new one. Default off (hard-cut), with a Settings → Visualizer toggle; falls back silently to a hard cut on capture failure and is suppressed under Reduce Motion / `prefers-reduced-motion`.
+- **Pin visualizer player controls** — keep the in-visualizer playback controls on screen instead of auto-hiding (Settings + a control-bar toggle).
+
+### Changed
+- **Quiet auto-advance** — when auto-advance changes the visualizer preset, it no longer wakes the overlay or shows the preset-name toast (the optional transition vignette still plays).
+- Production dependency refresh (React, React DOM, React Router, Zustand, Tailwind Vite plugin, `@types/react`); **Vite intentionally remains pinned to `8.0.9`** and no other dependency policy changed.
+
+### Notes
+- Beta tags now publish as **GitHub prereleases** — effective once this reaches `master` (the first prerelease-flagged tag is `v1.9.0-beta.4`).
+- No projectM engine / WASM behavior changed; preset switching remains a hard cut by default.
+
 ## [1.9.0-beta.3] - 2026-06-20
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,10 @@ LABEL org.opencontainers.image.title="Vibrdrome Web" \
 
 # Pull in latest Alpine security patches so the image isn't pinned to whatever
 # nginx:alpine shipped with (e.g. CVE-2026-27135 in nghttp2-libs).
-RUN apk upgrade --no-cache
+# Explicitly ensure libexpat >= 2.8.1-r0 to clear CVE-2026-45186 (HIGH, DoS via
+# crafted XML) — the fixed package is in the Alpine 3.23 main repo. The explicit
+# line also busts stale CI build cache so the upgrade actually re-runs.
+RUN apk upgrade --no-cache && apk add --no-cache "libexpat>=2.8.1-r0"
 
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.1",
+  "version": "1.9.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.1",
+      "version": "1.9.0-beta.3",
       "dependencies": {
-        "@tailwindcss/vite": "^4.2.4",
+        "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",
         "butterchurn-presets": "^2.4.7",
         "idb": "^8.0.3",
         "md5": "^2.3.0",
-        "react": "^19.2.5",
-        "react-dom": "^19.2.5",
-        "react-router-dom": "^7.15.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router-dom": "^7.18.0",
         "tailwindcss": "^4.2.2",
-        "zustand": "^5.0.13"
+        "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -25,7 +25,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/md5": "^2.3.6",
         "@types/node": "^25.6.0",
-        "@types/react": "^19.2.14",
+        "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^10.3.0",
@@ -1062,47 +1062,47 @@
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
-      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
+      "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "^5.19.0",
-        "jiti": "^2.6.1",
+        "enhanced-resolve": "5.21.6",
+        "jiti": "^2.7.0",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.2.4"
+        "tailwindcss": "4.3.1"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
-      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
+      "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.2.4",
-        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
-        "@tailwindcss/oxide-darwin-x64": "4.2.4",
-        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
-        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
-        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+        "@tailwindcss/oxide-android-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-x64": "4.3.1",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.1",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.1",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.1",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
-      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
+      "integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
       "cpu": [
         "arm64"
       ],
@@ -1116,9 +1116,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
-      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
+      "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
       "cpu": [
         "arm64"
       ],
@@ -1132,9 +1132,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
-      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
+      "integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
       "cpu": [
         "x64"
       ],
@@ -1148,9 +1148,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
-      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
+      "integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
       "cpu": [
         "x64"
       ],
@@ -1164,9 +1164,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
-      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
+      "integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
       "cpu": [
         "arm"
       ],
@@ -1180,11 +1180,14 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
-      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
+      "integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1196,11 +1199,14 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
-      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
+      "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1212,11 +1218,14 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
-      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
+      "integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1228,11 +1237,14 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
-      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
+      "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1244,9 +1256,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
-      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
+      "integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -1261,11 +1273,11 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.8.1",
-        "@emnapi/runtime": "^1.8.1",
-        "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.1.1",
-        "@tybys/wasm-util": "^0.10.1",
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1273,17 +1285,17 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.8.1",
+      "version": "1.10.0",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
+      "version": "1.10.0",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -1292,7 +1304,7 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
+      "version": "1.2.1",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -1301,22 +1313,24 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
+      "version": "1.1.4",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
         "@tybys/wasm-util": "^0.10.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
+      "version": "0.10.2",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -1331,9 +1345,9 @@
       "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
-      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
+      "integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
       "cpu": [
         "arm64"
       ],
@@ -1347,9 +1361,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
-      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
+      "integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
       "cpu": [
         "x64"
       ],
@@ -1363,14 +1377,14 @@
       }
     },
     "node_modules/@tailwindcss/vite": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.4.tgz",
-      "integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.1.tgz",
+      "integrity": "sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==",
       "license": "MIT",
       "dependencies": {
-        "@tailwindcss/node": "4.2.4",
-        "@tailwindcss/oxide": "4.2.4",
-        "tailwindcss": "4.2.4"
+        "@tailwindcss/node": "4.3.1",
+        "@tailwindcss/oxide": "4.3.1",
+        "tailwindcss": "4.3.1"
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
@@ -1527,9 +1541,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2407,13 +2421,13 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -3035,9 +3049,9 @@
       "license": "ISC"
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -3922,24 +3936,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-is": {
@@ -3951,9 +3965,9 @@
       "peer": true
     },
     "node_modules/react-router": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
-      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
+      "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3973,12 +3987,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
-      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz",
+      "integrity": "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.15.0"
+        "react-router": "7.18.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -4289,9 +4303,9 @@
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
-      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -4931,9 +4945,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
-      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.3",
+  "version": "1.9.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.3",
+      "version": "1.9.0-beta.4",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.3",
+  "version": "1.9.0-beta.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -14,16 +14,16 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@tailwindcss/vite": "^4.2.4",
+    "@tailwindcss/vite": "^4.3.1",
     "butterchurn": "^2.6.7",
     "butterchurn-presets": "^2.4.7",
     "idb": "^8.0.3",
     "md5": "^2.3.0",
-    "react": "^19.2.5",
-    "react-dom": "^19.2.5",
-    "react-router-dom": "^7.15.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router-dom": "^7.18.0",
     "tailwindcss": "^4.2.2",
-    "zustand": "^5.0.13"
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -31,7 +31,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/md5": "^2.3.6",
     "@types/node": "^25.6.0",
-    "@types/react": "^19.2.14",
+    "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^10.3.0",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -24,6 +24,7 @@ export default function SettingsScreen() {
     visualizerTransitionPolish, setVisualizerTransitionPolish,
     visualizerParticles, setVisualizerParticles,
     visualizerPinControls, setVisualizerPinControls,
+    visualizerPresetTransition, setVisualizerPresetTransition,
   } = useUIStore();
   const eqEnabled = useEQStore((s) => s.enabled);
 
@@ -393,6 +394,30 @@ export default function SettingsScreen() {
                     <span
                       className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
                         visualizerShowTransport ? 'translate-x-5' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
+              </div>
+
+              {/* Preset crossfade (projectM/WebGPU) */}
+              <div className="border-t border-border pt-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <span className="text-sm text-text-primary">Crossfade preset transitions</span>
+                    <p className="text-xs text-text-muted">Fade the old preset out over the new one (projectM/WebGPU only). Hard-cut otherwise. Suppressed when Reduce Motion is on</p>
+                  </div>
+                  <button
+                    role="switch"
+                    aria-checked={visualizerPresetTransition === 'fade'}
+                    onClick={() => setVisualizerPresetTransition(visualizerPresetTransition === 'fade' ? 'hard-cut' : 'fade')}
+                    className={`relative h-6 w-11 rounded-full transition-colors ${
+                      visualizerPresetTransition === 'fade' ? 'bg-accent' : 'bg-bg-tertiary'
+                    }`}
+                  >
+                    <span
+                      className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                        visualizerPresetTransition === 'fade' ? 'translate-x-5' : 'translate-x-0'
                       }`}
                     />
                   </button>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -23,6 +23,7 @@ export default function SettingsScreen() {
     visualizerShowTransport, setVisualizerShowTransport,
     visualizerTransitionPolish, setVisualizerTransitionPolish,
     visualizerParticles, setVisualizerParticles,
+    visualizerPinControls, setVisualizerPinControls,
   } = useUIStore();
   const eqEnabled = useEQStore((s) => s.enabled);
 
@@ -440,6 +441,30 @@ export default function SettingsScreen() {
                     <span
                       className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
                         visualizerParticles ? 'translate-x-5' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
+              </div>
+
+              {/* Keep player controls on screen */}
+              <div className="border-t border-border pt-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <span className="text-sm text-text-primary">Keep player controls on screen</span>
+                    <p className="text-xs text-text-muted">Pin the in-visualizer playback controls instead of letting them auto-hide</p>
+                  </div>
+                  <button
+                    role="switch"
+                    aria-checked={visualizerPinControls}
+                    onClick={() => setVisualizerPinControls(!visualizerPinControls)}
+                    className={`relative h-6 w-11 rounded-full transition-colors ${
+                      visualizerPinControls ? 'bg-accent' : 'bg-bg-tertiary'
+                    }`}
+                  >
+                    <span
+                      className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                        visualizerPinControls ? 'translate-x-5' : 'translate-x-0'
                       }`}
                     />
                   </button>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.3</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.4</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -222,6 +222,7 @@ export default function VisualizerScreen() {
     visualizerShowTransport,
     visualizerTransitionPolish,
     visualizerParticles,
+    visualizerPinControls, setVisualizerPinControls,
     reduceMotion,
     keyboardShortcutsEnabled,
   } = useUIStore();
@@ -252,6 +253,9 @@ export default function VisualizerScreen() {
   const [toastText, setToastText] = useState(''); // retained during the toast's fade-out
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const vignetteRef = useRef<HTMLDivElement>(null);
+  // Set just before an auto-advance preset change so the toast + overlay stay
+  // silent for that change (the optional vignette still plays).
+  const suppressNextToastRef = useRef(false);
   // Which Milkdrop engine is active: 'projectm' (WebGPU) or 'butterchurn'
   // (fallback), decided when milkdrop mode activates.
   const [milkdropEngine, setMilkdropEngine] = useState<'projectm' | 'butterchurn' | null>(null);
@@ -773,14 +777,30 @@ export default function VisualizerScreen() {
     resetOverlayTimer();
   };
 
+  // Silent preset change driven by the auto-advance timer: changes the preset
+  // without waking the overlay or showing the toast (the vignette still plays).
+  // Uses the functional updater so it never reads a stale index from the interval.
+  const autoAdvance = () => {
+    suppressNextToastRef.current = true;
+    if (visualizerShuffle) {
+      setActiveIndex((i) => {
+        if (totalPresets <= 1) return i;
+        let next: number;
+        do {
+          next = Math.floor(Math.random() * totalPresets);
+        } while (next === i);
+        return next;
+      });
+    } else {
+      setActiveIndex((i) => (i + 1) % totalPresets);
+    }
+  };
+
   // Auto-advance: cycle presets on the configured interval while in Milkdrop.
   useEffect(() => {
     if (mode !== 'milkdrop' || !milkdropReady || !visualizerAutoAdvance) return;
     const ms = Math.max(1, visualizerAutoAdvanceInterval) * 1000;
-    const id = setInterval(() => {
-      if (visualizerShuffle) randomPreset();
-      else nextPreset();
-    }, ms);
+    const id = setInterval(autoAdvance, ms);
     return () => clearInterval(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, milkdropReady, visualizerAutoAdvance, visualizerAutoAdvanceInterval, visualizerShuffle]);
@@ -837,10 +857,16 @@ export default function VisualizerScreen() {
     // Skip the initial mount and the transient "Loading..." placeholder.
     if (prev === null || !name || name === 'Loading...' || name === prev) return;
 
-    setToastText(name);
-    setPresetToast(name);
-    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
-    toastTimerRef.current = setTimeout(() => setPresetToast(null), 1800);
+    // Auto-advance changes are silent: no toast (and the timer never woke the
+    // overlay). The vignette below still plays for smooth slideshow transitions.
+    const silent = suppressNextToastRef.current;
+    suppressNextToastRef.current = false;
+    if (!silent) {
+      setToastText(name);
+      setPresetToast(name);
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+      toastTimerRef.current = setTimeout(() => setPresetToast(null), 1800);
+    }
 
     if (visualizerTransitionPolish && !motionReduced) {
       const el = vignetteRef.current;
@@ -1030,12 +1056,27 @@ export default function VisualizerScreen() {
             <button onClick={(e) => { e.stopPropagation(); toggleFps(); }} title="FPS overlay (F)" className={ctrlBtn(showFps)}>
               FPS
             </button>
+            {visualizerShowTransport && (
+              <button onClick={(e) => { e.stopPropagation(); setVisualizerPinControls(!visualizerPinControls); resetOverlayTimer(); }} title="Keep player controls on screen" className={ctrlBtn(visualizerPinControls)}>
+                📌 Pin
+              </button>
+            )}
           </div>
         )}
-
-        {/* In-visualizer playback transport (opt-in; self-hides with no song) */}
-        {visualizerShowTransport && <VisualizerTransport onInteract={resetOverlayTimer} />}
       </div>
+
+      {/* In-visualizer playback transport (opt-in; self-hides with no song).
+          Lives outside the auto-hiding overlay so the Pin toggle can keep just
+          the player controls on screen while the rest of the HUD still fades. */}
+      {visualizerShowTransport && (
+        <div
+          className={`transition-opacity duration-500 ${
+            showOverlay || visualizerPinControls ? 'opacity-100' : 'pointer-events-none opacity-0'
+          }`}
+        >
+          <VisualizerTransport onInteract={resetOverlayTimer} />
+        </div>
+      )}
 
       {/* FPS overlay — persists regardless of the auto-hiding controls */}
       {showFps && (

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -8,6 +8,7 @@ import VisualizerTransport from '../components/visualizer/VisualizerTransport';
 import VisualizerHud from '../components/visualizer/VisualizerHud';
 import ParticleOverlay from '../components/visualizer/ParticleOverlay';
 import { useMediaQuery } from '../hooks/useMediaQuery';
+import { shouldCrossfade, captureSnapshot } from '../utils/presetCrossfade';
 import type { PresetIndexEntry } from '../types/presets';
 
 // projectM preset category that is excluded from normal selection: these are
@@ -223,6 +224,7 @@ export default function VisualizerScreen() {
     visualizerTransitionPolish,
     visualizerParticles,
     visualizerPinControls, setVisualizerPinControls,
+    visualizerPresetTransition,
     reduceMotion,
     keyboardShortcutsEnabled,
   } = useUIStore();
@@ -231,6 +233,47 @@ export default function VisualizerScreen() {
   // reduce-motion setting or the OS prefers-reduced-motion media query.
   const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
   const motionReduced = reduceMotion || prefersReducedMotion;
+
+  // Frozen-frame crossfade (projectM path). Refs keep the preset-load effect from
+  // re-running when the setting/motion changes (toggling must not reload presets).
+  const fadeImgRef = useRef<HTMLImageElement>(null);
+  const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pmFadeArmedRef = useRef(false); // a projectM preset has rendered → safe to capture
+  const transitionRef = useRef(visualizerPresetTransition);
+  const motionReducedRef = useRef(motionReduced);
+  useEffect(() => { transitionRef.current = visualizerPresetTransition; }, [visualizerPresetTransition]);
+  useEffect(() => { motionReducedRef.current = motionReduced; }, [motionReduced]);
+
+  // Show the captured old frame (a JPEG data URL), then fade it out over the new
+  // live preset. Pure DOM on a ref'd <img> — no React state churn during the
+  // fade, and data URLs need no revoking. A monotonic token guards against rapid
+  // switches superseding an in-flight fade.
+  const fadeTokenRef = useRef(0);
+  const runSnapshotFade = useCallback((url: string) => {
+    const img = fadeImgRef.current;
+    if (!img) return;
+    const token = ++fadeTokenRef.current;
+    if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
+    img.style.transition = 'none';
+    img.style.opacity = '1';
+    img.src = url;
+    img.style.display = 'block';
+    // Double rAF so opacity:1 paints before transitioning to 0.
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      if (fadeTokenRef.current !== token || !fadeImgRef.current) return; // superseded/unmounted
+      fadeImgRef.current.style.transition = 'opacity 450ms ease-out';
+      fadeImgRef.current.style.opacity = '0';
+    }));
+    fadeTimerRef.current = setTimeout(() => {
+      if (fadeTokenRef.current !== token) return;
+      if (fadeImgRef.current) { fadeImgRef.current.style.display = 'none'; fadeImgRef.current.removeAttribute('src'); }
+    }, 520);
+  }, []);
+
+  // Clean up any in-flight fade timer on unmount.
+  useEffect(() => () => {
+    if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
+  }, []);
 
   // Subscribed only to decide whether the in-overlay transport renders (so the
   // bottom control bar / FPS overlay can shift up to make room for it).
@@ -610,6 +653,7 @@ export default function VisualizerScreen() {
       const engine = await wasm.PmEngine.create(canvas, canvas.width, canvas.height);
       if (cancelled) { engine.free(); return; }
       pmEngineRef.current = engine;
+      pmFadeArmedRef.current = false; // fresh engine: don't fade from a blank first frame
 
       // Preset library from the preset store (manifest only — shards lazy-load).
       // Exclude the "! Transition" category from the selectable list: those are
@@ -736,13 +780,31 @@ export default function VisualizerScreen() {
       .getPresetText(entry.path)
       .then((text) => {
         if (cancelled || !text) return;
-        engine.load_preset(text); // hard cut
+        const canvas = projectmCanvasRef.current;
+        const fade = shouldCrossfade({
+          transition: transitionRef.current,
+          motionReduced: motionReducedRef.current,
+          armed: pmFadeArmedRef.current,
+          hasCanvas: !!canvas,
+        });
+        // First load of a projectM session has no prior frame to fade from.
+        pmFadeArmedRef.current = true;
+        if (fade && canvas) {
+          // Capture the OLD frame (synchronous), then hard-cut underneath the
+          // still and fade it out. Any capture failure → silent hard-cut.
+          captureSnapshot(canvas, (url) => {
+            if (url) runSnapshotFade(url);
+            engine.load_preset(text); // hard cut (hidden behind the still if captured)
+          });
+        } else {
+          engine.load_preset(text); // hard cut
+        }
       })
       .catch((err) => console.error('[Visualizer] projectM preset load failed', err));
     return () => {
       cancelled = true;
     };
-  }, [milkdropPresetIndex, milkdropEngine, mode]);
+  }, [milkdropPresetIndex, milkdropEngine, mode, runSnapshotFade]);
 
   // Auto-hide overlay
   useEffect(() => {
@@ -924,6 +986,16 @@ export default function VisualizerScreen() {
         className={`absolute inset-0 h-full w-full ${
           mode === 'milkdrop' && milkdropEngine === 'projectm' ? '' : 'hidden'
         }`}
+      />
+
+      {/* Frozen-frame crossfade still — sits above the projectM canvas, briefly
+          shown then faded out on a preset change (driven imperatively via ref). */}
+      <img
+        ref={fadeImgRef}
+        alt=""
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 h-full w-full object-cover"
+        style={{ display: 'none', opacity: 0 }}
       />
 
       {/* Milkdrop loading indicator */}

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -249,25 +249,37 @@ export default function VisualizerScreen() {
   // fade, and data URLs need no revoking. A monotonic token guards against rapid
   // switches superseding an in-flight fade.
   const fadeTokenRef = useRef(0);
-  const runSnapshotFade = useCallback((url: string) => {
+  const runSnapshotFade = useCallback((url: string, hardCut: () => void) => {
     const img = fadeImgRef.current;
-    if (!img) return;
+    if (!img) { hardCut(); return; }
     const token = ++fadeTokenRef.current;
     if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
     img.style.transition = 'none';
     img.style.opacity = '1';
-    img.src = url;
     img.style.display = 'block';
-    // Double rAF so opacity:1 paints before transitioning to 0.
-    requestAnimationFrame(() => requestAnimationFrame(() => {
-      if (fadeTokenRef.current !== token || !fadeImgRef.current) return; // superseded/unmounted
-      fadeImgRef.current.style.transition = 'opacity 450ms ease-out';
-      fadeImgRef.current.style.opacity = '0';
-    }));
-    fadeTimerRef.current = setTimeout(() => {
-      if (fadeTokenRef.current !== token) return;
-      if (fadeImgRef.current) { fadeImgRef.current.style.display = 'none'; fadeImgRef.current.removeAttribute('src'); }
-    }, 520);
+    img.src = url;
+
+    const begin = () => {
+      if (fadeTokenRef.current !== token || !fadeImgRef.current) { hardCut(); return; }
+      // The still is decoded and covering the canvas at full opacity → hard-cut
+      // the new preset underneath it, then fade the still out to reveal it.
+      hardCut();
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        if (fadeTokenRef.current !== token || !fadeImgRef.current) return;
+        fadeImgRef.current.style.transition = 'opacity 1400ms ease-out';
+        fadeImgRef.current.style.opacity = '0';
+      }));
+      fadeTimerRef.current = setTimeout(() => {
+        if (fadeTokenRef.current !== token) return;
+        if (fadeImgRef.current) { fadeImgRef.current.style.display = 'none'; fadeImgRef.current.removeAttribute('src'); }
+      }, 1500);
+    };
+
+    // Decode the still BEFORE hard-cutting. A large JPEG data URL decodes
+    // asynchronously; showing it pre-decode would leave the new preset visible
+    // underneath and read as a hard cut. decode() guarantees it actually paints.
+    if (typeof img.decode === 'function') img.decode().then(begin).catch(begin);
+    else { img.onload = begin; }
   }, []);
 
   // Clean up any in-flight fade timer on unmount.
@@ -789,15 +801,17 @@ export default function VisualizerScreen() {
         });
         // First load of a projectM session has no prior frame to fade from.
         pmFadeArmedRef.current = true;
+        const hardCut = () => { if (!cancelled) engine.load_preset(text); };
         if (fade && canvas) {
-          // Capture the OLD frame (synchronous), then hard-cut underneath the
-          // still and fade it out. Any capture failure → silent hard-cut.
+          // Capture the OLD frame (synchronous). The fade decodes the still, then
+          // hard-cuts the new preset underneath it and fades the still out. Any
+          // capture failure → silent hard-cut.
           captureSnapshot(canvas, (url) => {
-            if (url) runSnapshotFade(url);
-            engine.load_preset(text); // hard cut (hidden behind the still if captured)
+            if (url) runSnapshotFade(url, hardCut);
+            else hardCut();
           });
         } else {
-          engine.load_preset(text); // hard cut
+          hardCut();
         }
       })
       .catch((err) => console.error('[Visualizer] projectM preset load failed', err));

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -18,6 +18,7 @@ const VIS_SHUFFLE_KEY = 'vibrdrome_visualizer_shuffle';
 const VIS_SHOW_TRANSPORT_KEY = 'vibrdrome_visualizer_show_transport';
 const VIS_TRANSITION_POLISH_KEY = 'vibrdrome_visualizer_transition_polish';
 const VIS_PARTICLES_KEY = 'vibrdrome_visualizer_particles';
+const VIS_PIN_CONTROLS_KEY = 'vibrdrome_visualizer_pin_controls';
 const DEFAULT_ACCENT = '#8b5cf6';
 
 type Theme = 'system' | 'dark' | 'light' | 'apple' | 'apple-dark' | 'retro' | 'terminal' | 'midnight' | 'sunset';
@@ -74,6 +75,8 @@ interface UIState {
   setVisualizerTransitionPolish: (value: boolean) => void;
   visualizerParticles: boolean;
   setVisualizerParticles: (value: boolean) => void;
+  visualizerPinControls: boolean;
+  setVisualizerPinControls: (value: boolean) => void;
 
   castConnected: boolean;
   setCastConnected: (connected: boolean) => void;
@@ -250,6 +253,13 @@ export const useUIStore = create<UIState>((set) => ({
   setVisualizerParticles: (value) => {
     try { localStorage.setItem(VIS_PARTICLES_KEY, String(value)); } catch { /* ignore */ }
     set({ visualizerParticles: value });
+  },
+  // Keep the in-visualizer player controls (transport) on screen instead of
+  // auto-hiding with the rest of the overlay. Default off.
+  visualizerPinControls: loadBool(VIS_PIN_CONTROLS_KEY, false),
+  setVisualizerPinControls: (value) => {
+    try { localStorage.setItem(VIS_PIN_CONTROLS_KEY, String(value)); } catch { /* ignore */ }
+    set({ visualizerPinControls: value });
   },
 
   castConnected: false,

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -19,6 +19,7 @@ const VIS_SHOW_TRANSPORT_KEY = 'vibrdrome_visualizer_show_transport';
 const VIS_TRANSITION_POLISH_KEY = 'vibrdrome_visualizer_transition_polish';
 const VIS_PARTICLES_KEY = 'vibrdrome_visualizer_particles';
 const VIS_PIN_CONTROLS_KEY = 'vibrdrome_visualizer_pin_controls';
+const VIS_PRESET_TRANSITION_KEY = 'vibrdrome_visualizer_preset_transition';
 const DEFAULT_ACCENT = '#8b5cf6';
 
 type Theme = 'system' | 'dark' | 'light' | 'apple' | 'apple-dark' | 'retro' | 'terminal' | 'midnight' | 'sunset';
@@ -77,6 +78,8 @@ interface UIState {
   setVisualizerParticles: (value: boolean) => void;
   visualizerPinControls: boolean;
   setVisualizerPinControls: (value: boolean) => void;
+  visualizerPresetTransition: 'hard-cut' | 'fade';
+  setVisualizerPresetTransition: (value: 'hard-cut' | 'fade') => void;
 
   castConnected: boolean;
   setCastConnected: (connected: boolean) => void;
@@ -260,6 +263,16 @@ export const useUIStore = create<UIState>((set) => ({
   setVisualizerPinControls: (value) => {
     try { localStorage.setItem(VIS_PIN_CONTROLS_KEY, String(value)); } catch { /* ignore */ }
     set({ visualizerPinControls: value });
+  },
+  // Preset-change transition on the projectM/WebGPU path: 'hard-cut' (default)
+  // or 'fade' (frozen-frame crossfade). Always suppressed under reduced motion.
+  visualizerPresetTransition: (() => {
+    try { return localStorage.getItem(VIS_PRESET_TRANSITION_KEY) === 'fade' ? 'fade' : 'hard-cut'; }
+    catch { return 'hard-cut'; }
+  })(),
+  setVisualizerPresetTransition: (value) => {
+    try { localStorage.setItem(VIS_PRESET_TRANSITION_KEY, value); } catch { /* ignore */ }
+    set({ visualizerPresetTransition: value });
   },
 
   castConnected: false,

--- a/src/utils/presetCrossfade.test.ts
+++ b/src/utils/presetCrossfade.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shouldCrossfade, captureSnapshot } from './presetCrossfade';
+
+describe('shouldCrossfade', () => {
+  const base = { transition: 'fade' as const, motionReduced: false, armed: true, hasCanvas: true };
+
+  it('default hard-cut never crossfades', () => {
+    expect(shouldCrossfade({ ...base, transition: 'hard-cut' })).toBe(false);
+  });
+
+  it('reduced motion suppresses the fade', () => {
+    expect(shouldCrossfade({ ...base, motionReduced: true })).toBe(false);
+  });
+
+  it('does not fade before a previous preset has rendered (not armed)', () => {
+    expect(shouldCrossfade({ ...base, armed: false })).toBe(false);
+  });
+
+  it('does not fade without a canvas', () => {
+    expect(shouldCrossfade({ ...base, hasCanvas: false })).toBe(false);
+  });
+
+  it('fades when enabled, armed, has a canvas, and motion is not reduced', () => {
+    expect(shouldCrossfade(base)).toBe(true);
+  });
+});
+
+describe('captureSnapshot', () => {
+  const canvasWith = (toDataURL: HTMLCanvasElement['toDataURL']) => ({ toDataURL }) as unknown as HTMLCanvasElement;
+
+  it('returns the data URL when capture succeeds', () => {
+    const canvas = canvasWith(() => 'data:image/jpeg;base64,abc');
+    const cb = vi.fn();
+    captureSnapshot(canvas, cb);
+    expect(cb).toHaveBeenCalledWith('data:image/jpeg;base64,abc');
+  });
+
+  it('passes the JPEG mime + quality to toDataURL', () => {
+    const toDataURL = vi.fn(() => 'data:image/jpeg;base64,abc');
+    captureSnapshot(canvasWith(toDataURL as unknown as HTMLCanvasElement['toDataURL']), () => {}, 0.55);
+    expect(toDataURL).toHaveBeenCalledWith('image/jpeg', 0.55);
+  });
+
+  it('falls back (null) when toDataURL returns a non-image string', () => {
+    const canvas = canvasWith(() => 'data:,'); // e.g. blank/unsupported
+    const cb = vi.fn();
+    captureSnapshot(canvas, cb);
+    expect(cb).toHaveBeenCalledWith(null);
+  });
+
+  it('falls back (null) when toDataURL throws (e.g. tainted/unsupported)', () => {
+    const canvas = canvasWith(() => { throw new Error('no'); });
+    const cb = vi.fn();
+    captureSnapshot(canvas, cb);
+    expect(cb).toHaveBeenCalledWith(null);
+  });
+
+  it('calls back exactly once', () => {
+    const canvas = canvasWith(() => 'data:image/jpeg;base64,abc');
+    const cb = vi.fn();
+    captureSnapshot(canvas, cb);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/presetCrossfade.ts
+++ b/src/utils/presetCrossfade.ts
@@ -1,0 +1,49 @@
+// App-only frozen-frame crossfade helpers for the projectM/WebGPU visualizer.
+//
+// On a preset change we capture the current canvas as a still image, hard-cut to
+// the new preset underneath, and fade the still out over the new live preset.
+// No second engine, no extra GPU context, no projectM-rs change.
+
+export type PresetTransition = 'hard-cut' | 'fade';
+
+/**
+ * Decide whether a preset change should crossfade. Fade only when:
+ * - the user picked 'fade',
+ * - reduced motion is NOT active (in-app setting or OS preference),
+ * - a previous preset has already rendered (so there's an old frame to capture),
+ * - a canvas is available.
+ * Otherwise the caller hard-cuts.
+ */
+export function shouldCrossfade(opts: {
+  transition: PresetTransition;
+  motionReduced: boolean;
+  armed: boolean;
+  hasCanvas: boolean;
+}): boolean {
+  return opts.transition === 'fade' && !opts.motionReduced && opts.armed && opts.hasCanvas;
+}
+
+/**
+ * Capture the current canvas frame as a data URL for the crossfade.
+ *
+ * Uses synchronous `toDataURL('image/jpeg', …)` — the validated, portable capture
+ * path: `toDataURL`/`toBlob` are the only methods that work on BOTH real GPU and
+ * software/fallback WebGPU (`drawImage`/`createImageBitmap` come back blank on
+ * software WebGPU). Synchronous so the still is guaranteed ready *before* the
+ * hard-cut (no async race / mis-ordered frame); JPEG keeps the one-off encode
+ * cheap (PNG is the expensive part). Calls back with the data URL, or `null` if
+ * capture failed/threw so the caller hard-cuts. Never captures per-frame — only
+ * once per transition. Data URLs need no revoking.
+ */
+export function captureSnapshot(
+  canvas: HTMLCanvasElement,
+  cb: (url: string | null) => void,
+  quality = 0.55,
+): void {
+  try {
+    const url = canvas.toDataURL('image/jpeg', quality);
+    cb(typeof url === 'string' && url.startsWith('data:image') ? url : null);
+  } catch {
+    cb(null);
+  }
+}


### PR DESCRIPTION
## Release v1.9.0-beta.4

Promotes the queued `develop` work to production. Metadata version is `1.9.0-beta.4`.

### Included
- **Quiet auto-advance + pinned visualizer player controls** (#45) — auto-advance no longer wakes the overlay/toast; option to keep the in-visualizer playback controls on screen.
- **Production dependency refresh** (#26) — React/router/zustand/tailwind-plugin/@types/react. **Vite intentionally still pinned to `8.0.9`.**
- **Beta tags now publish as GitHub prereleases** (#46) — effective from this release onward (`v1.9.0-beta.4` is the first prerelease-flagged tag).
- **projectM frozen-frame preset crossfade** (#47) — **default off** (hard-cut), with a Settings toggle; silent hard-cut fallback on capture failure, suppressed under reduced motion.
- **Docker libexpat CVE scan blocker fix** (#49) — explicit `apk add "libexpat>=2.8.1-r0"` clears `CVE-2026-45186` (HIGH) in the `nginx:alpine` base.
- **Version metadata** bumped to `1.9.0-beta.4` (package.json / lockfile / About string / CHANGELOG).

### Intentionally excluded / held
- **PR #27** — dev-dependencies bump that moves **Vite 8.0.9 → 8.0.16** (the black-screen risk class); held pending a dedicated Vite validation.
- **PR #22** — `cloudflare/wrangler-action v3 → v4`; held to keep deploy-action risk out of this feature release.

### Notes
- No projectM engine / WASM behavior changed; preset switching remains hard-cut by default.
- No dependency policy changes beyond the #26 refresh; Vite stays `8.0.9`.

### Verification
`develop` is fully green (lint/test/build incl. `test:smoke`/docker/scan); 186 tests; the repo-wide libexpat scan blocker is fixed. Tag `v1.9.0-beta.4` (publishes as a **prerelease**) + production verification follow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)