### PR TITLE
Prepare v1.9.0-beta.5 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.5] - 2026-06-21
+
+### Fixed
+- **projectM feedback-buffer inheritance** — feedback/transition-style Milkdrop presets that draw from the previous frame (e.g. "Angels Of Glory … Isosceles edit", "Goody – Growth effect", "nematodes (Reverse Jelly V3)", "Water Baqteria") no longer render as a black screen after a preset switch. The projectM/WebGPU engine now copies the previous preset's last completed frame into the newly-loaded preset's feedback buffer (a GPU texture-to-texture copy; a cold first-load with no prior frame is unchanged), so these presets inherit previous-frame content instead of starting from black. Ships as a re-vendored `pm-web` WASM build; engine source fix is [`projectM-rs#1`](https://github.com/ddmoney420/projectM-rs/pull/1).
+
+### Changed
+- Dev-tooling/dependency refresh (dev-dependencies group). **Vite unpinned from `8.0.9` to `8.0.16`** after explicit production-preview validation against the 1.9.0-beta.1 black-screen / entry-chunking failure (the `npm run test:smoke` guard remains wired into CI). No production-dependency policy changes.
+
+### Notes
+- No application source changed in this release beyond version metadata; the projectM fix is entirely in the re-vendored engine WASM. Preset switching remains a hard cut by default.
+
 ## [1.9.0-beta.4] - 2026-06-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.4",
+  "version": "1.9.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.4",
+      "version": "1.9.0-beta.5",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.4",
+  "version": "1.9.0-beta.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.4</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.5</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">


### PR DESCRIPTION
Release-metadata prep for **v1.9.0-beta.5**. Metadata only — no code/behavior changes.

## Version bump
`1.9.0-beta.4` → `1.9.0-beta.5` in:
- `package.json`
- `package-lock.json` (root + `packages[""]` version only — no dependency changes)
- `src/screens/SettingsScreen.tsx` (About string → `Vibrdrome Web v1.9.0-beta.5`)

## CHANGELOG — new `## [1.9.0-beta.5] - 2026-06-21`
- **Fixed:** projectM **feedback-buffer inheritance** via re-vendored `pm-web` WASM — feedback/transition-style presets that depend on previous-frame content (Angels Of Glory, Goody Growth effect, nematodes, Water Baqteria, …) now render visibly after a preset switch instead of starting black. Engine source fix: [`projectM-rs#1`](https://github.com/ddmoney420/projectM-rs/pull/1) (PR #51 re-vendor).
- **Changed:** dev-dependencies refresh with **Vite unpinned `8.0.9` → `8.0.16`** after explicit production-preview validation against the beta.1 black-screen/chunking failure (`test:smoke` guard still in CI). No production-dependency policy changes (PR #27).

## Scope / guardrails
- ✅ No dependency changes beyond already-merged PR #27.
- ✅ No app source changes (only the About version string).
- ✅ No Dockerfile/workflow changes.
- ✅ **PR #22 (Wrangler v4) remains held/excluded** — not referenced, not included.
- ✅ No `master`, tag, GitHub Release, or deploy — this targets `develop` only.

## Validation
`npm run lint` ✅ · `npm run test:run` ✅ 186/186 · `npm run build` ✅ · `npm run test:smoke` ✅ (root mounted, 0 console errors).