### PR TITLE
Prepare v1.9.0-beta.6 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.6] - 2026-06-21
+
+### Changed
+- **Live engine-level projectM/WebGPU preset crossfade.** When the existing "Crossfade preset transitions" (`fade`) setting is on, projectM/WebGPU preset switches now blend in the **engine** — both the outgoing and incoming presets keep rendering live and their outputs are mixed across the transition — instead of fading a frozen still of the old frame. Re-vendored `pm-web` WASM exposing the new `transition_to_preset` API; engine source fix is [`projectM-rs#2`](https://github.com/ddmoney420/projectM-rs/pull/2).
+
+### Notes
+- **Hard-cut remains the default**; the live crossfade only applies when `fade` is enabled.
+- **Reduced motion** (in-app setting or `prefers-reduced-motion`) still suppresses the transition (hard-cut).
+- **Butterchurn** (WebGL fallback) behavior is unchanged.
+- The previous **frozen-frame crossfade remains as a fallback** for older/unavailable pm-web builds (feature-detected). No UI/settings change.
+
 ## [1.9.0-beta.5] - 2026-06-21
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.5",
+  "version": "1.9.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.5",
+      "version": "1.9.0-beta.6",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.5",
+  "version": "1.9.0-beta.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.5</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.6</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">


### PR DESCRIPTION
Release-metadata prep for **v1.9.0-beta.6**. Metadata only — no code/behavior changes.

## Version bump
`1.9.0-beta.5` → `1.9.0-beta.6` in:
- `package.json`
- `package-lock.json` (root + `packages[""]` version only — no dependency changes)
- `src/screens/SettingsScreen.tsx` (About → `Vibrdrome Web v1.9.0-beta.6`)

## CHANGELOG — new `## [1.9.0-beta.6] - 2026-06-21`
- **Changed:** live engine-level projectM/WebGPU preset crossfade under the existing `fade` setting — both presets render live and blend in the engine instead of fading a frozen still (re-vendored `pm-web` `transition_to_preset`; engine source [`projectM-rs#2`](https://github.com/ddmoney420/projectM-rs/pull/2)).
- **Notes:** hard-cut remains default; reduced-motion still suppresses transitions; butterchurn unchanged; frozen-frame crossfade remains the fallback for older pm-web (feature-detected); no UI/settings change.

## Scope / guardrails
- Beta.6 payload is exactly **PR #54** (already merged to `develop`); this PR adds only version metadata + CHANGELOG.
- No app behavior changes beyond PR #54. No dependency, Dockerfile, or workflow changes.
- **PR #22 (Wrangler v4) remains held/excluded** — not referenced, not included.
- No `master`, tag, GitHub Release, or deploy — targets `develop` only.

## Validation
`npm run lint` ✅ · `npm run test:run` ✅ 186/186 · `npm run build` ✅ · `npm run test:smoke` ✅ (root mounted, 0 console errors).