### PR TITLE
Prepare v1.9.0-beta.7 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.7] - 2026-06-21
+
+### Changed
+- Updated the Cloudflare Pages deploy action from `cloudflare/wrangler-action@v3` to `@v4`. This clears the Node 20 deprecation warning seen during recent (successful) production deploys.
+
+### Notes
+- Deploy-maintenance beta only — **no app runtime changes, no visualizer changes, no dependency changes.**
+
 ## [1.9.0-beta.6] - 2026-06-21
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.6",
+  "version": "1.9.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.6",
+      "version": "1.9.0-beta.7",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.6",
+  "version": "1.9.0-beta.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.6</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.7</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">


### PR DESCRIPTION
Release-metadata prep for **v1.9.0-beta.7**, a **deploy-maintenance** beta. Metadata only — no code/behavior changes.

## Version bump
`1.9.0-beta.6` → `1.9.0-beta.7` in:
- `package.json`
- `package-lock.json` (root + `packages[""]` version only — no dependency changes)
- `src/screens/SettingsScreen.tsx` (About → `Vibrdrome Web v1.9.0-beta.7`)

## CHANGELOG — new `## [1.9.0-beta.7] - 2026-06-21`
- **Changed:** Cloudflare Pages deploy action `cloudflare/wrangler-action@v3` → `@v4` (already merged via PR #22), clearing the Node 20 deprecation warning from recent production deploys.
- **Notes:** deploy-maintenance only — no app/runtime changes, no visualizer changes, no dependency changes.

## Scope / guardrails
- beta.7 payload is exactly **PR #22** (already on `develop`); this PR adds only version metadata + CHANGELOG.
- No app/runtime feature changes, no visualizer changes, no dependency changes, no Dockerfile changes, no workflow changes beyond the already-merged PR #22.
- No `master`, tag, GitHub Release, or deploy — targets `develop` only.

## Validation
`npm run lint` ✅ · `npm run test:run` ✅ 186/186 · `npm run build` ✅ · `npm run test:smoke` ✅ (root mounted, 0 console errors).