### PR TITLE
Add visualizer preset search

### DIFF
--- a/src/components/visualizer/PresetSearch.test.tsx
+++ b/src/components/visualizer/PresetSearch.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PresetSearch from './PresetSearch';
+
+const NAMES = ['Alpha Bloom', 'Beta Wave', 'Gamma Spiral', 'Zebra Target'];
+
+describe('PresetSearch', () => {
+  it('caps rendered results and shows a refine hint when there are more matches', () => {
+    const many = Array.from({ length: 120 }, (_, i) => `Preset ${i}`);
+    render(<PresetSearch names={many} onSelect={() => {}} onClose={() => {}} />);
+    // Empty query lists all, but only the first 50 rows are rendered.
+    expect(screen.getAllByRole('option')).toHaveLength(50);
+    expect(screen.getByText(/Showing 50 of 120/)).toBeInTheDocument();
+  });
+
+  it('maps a fuzzy-sorted result back to its ORIGINAL index on click', () => {
+    const onSelect = vi.fn();
+    render(<PresetSearch names={NAMES} onSelect={onSelect} onClose={() => {}} />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'zebra' } });
+    fireEvent.click(screen.getByText('Zebra Target'));
+    expect(onSelect).toHaveBeenCalledWith(3); // original index in NAMES, not the filtered position
+  });
+
+  it('shows a no-match state', () => {
+    render(<PresetSearch names={NAMES} onSelect={() => {}} onClose={() => {}} />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'qqqzzz-nomatch' } });
+    expect(screen.getByText('No matching presets')).toBeInTheDocument();
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
+  });
+
+  it('selects the highlighted result with ArrowDown + Enter (original index)', () => {
+    const onSelect = vi.fn();
+    render(<PresetSearch names={NAMES} onSelect={onSelect} onClose={() => {}} />);
+    const input = screen.getByRole('textbox');
+    // 'a' matches several; highlight starts at 0, ArrowDown moves to the 2nd row.
+    fireEvent.change(input, { target: { value: 'a' } });
+    const options = screen.getAllByRole('option');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    // The 2nd visible row's text maps back to its original index in NAMES.
+    const chosenName = options[1].textContent ?? '';
+    expect(onSelect).toHaveBeenCalledWith(NAMES.indexOf(chosenName));
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(<PresetSearch names={NAMES} onSelect={() => {}} onClose={onClose} />);
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/visualizer/PresetSearch.tsx
+++ b/src/components/visualizer/PresetSearch.tsx
@@ -1,0 +1,141 @@
+// Visualizer-scoped preset search overlay. Filters the active engine's preset
+// name list and, on select, jumps by ORIGINAL index — the caller wires that to
+// the existing `setActiveIndex` preset-switch path, so all transition behaviour
+// (hard-cut / live crossfade / reduced-motion / butterchurn) is preserved with
+// no new rendering logic. Search is name-only (no preset text is loaded).
+//
+// Mounted only while open (the parent conditionally renders it), so it starts
+// with fresh state and an autofocused input each time.
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { fuzzyFilter } from '../../utils/fuzzySearch';
+
+const MAX_RESULTS = 50;
+
+interface PresetSearchProps {
+  /** Active engine's selectable preset names (projectM or butterchurn). */
+  names: string[];
+  /** Called with the ORIGINAL index into `names` for the chosen preset. */
+  onSelect: (index: number) => void;
+  onClose: () => void;
+}
+
+export default function PresetSearch({ names, onSelect, onClose }: PresetSearchProps) {
+  const [query, setQuery] = useState('');
+  const [highlight, setHighlight] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  // Pair each name with its original index so a fuzzy-sorted result still maps
+  // back to the correct preset index.
+  const items = useMemo(() => names.map((name, index) => ({ name, index })), [names]);
+  const matches = useMemo(() => fuzzyFilter(items, query, (i) => i.name), [items, query]);
+  const shown = matches.slice(0, MAX_RESULTS);
+  const overflow = matches.length - shown.length;
+
+  // Autofocus the input on mount.
+  useEffect(() => {
+    const id = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  // Keep the highlighted row scrolled into view (no state change here).
+  useEffect(() => {
+    (listRef.current?.children[highlight] as HTMLElement | undefined)?.scrollIntoView?.({ block: 'nearest' });
+  }, [highlight]);
+
+  const choose = (i: number) => {
+    const m = shown[i];
+    if (m) onSelect(m.index);
+  };
+
+  // Handle keys at the overlay level and stop propagation so the visualizer's
+  // global shortcuts never fire while searching. Printable keys fall through to
+  // the input (only navigation keys are intercepted).
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    e.stopPropagation();
+    switch (e.key) {
+      case 'Escape':
+        e.preventDefault();
+        onClose();
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        setHighlight((h) => Math.min(h + 1, shown.length - 1));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setHighlight((h) => Math.max(h - 1, 0));
+        break;
+      case 'Enter':
+        e.preventDefault();
+        choose(highlight);
+        break;
+      case 'Tab':
+        // Trap focus inside the overlay.
+        e.preventDefault();
+        inputRef.current?.focus();
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div
+      className="absolute inset-0 z-30 flex items-start justify-center bg-black/60 p-4 pt-16"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        className="w-full max-w-lg overflow-hidden rounded-lg border border-white/10 bg-bg-secondary shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={onKeyDown}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search presets"
+      >
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setHighlight(0);
+          }}
+          placeholder={`Search ${names.length} presets…`}
+          aria-label="Search presets"
+          className="w-full bg-transparent px-4 py-3 text-sm text-white outline-none placeholder:text-white/40"
+        />
+        <ul
+          ref={listRef}
+          className="max-h-80 overflow-y-auto border-t border-white/10"
+          role="listbox"
+          aria-label="Preset results"
+        >
+          {shown.length === 0 ? (
+            <li className="px-4 py-3 text-sm text-white/50">No matching presets</li>
+          ) : (
+            shown.map((m, i) => (
+              <li
+                key={m.index}
+                role="option"
+                aria-selected={i === highlight}
+                onClick={() => choose(i)}
+                onMouseMove={() => setHighlight(i)}
+                className={`cursor-pointer truncate px-4 py-2 text-sm ${
+                  i === highlight ? 'bg-white/15 text-white' : 'text-white/80'
+                }`}
+              >
+                {m.name}
+              </li>
+            ))
+          )}
+        </ul>
+        {overflow > 0 && (
+          <div className="border-t border-white/10 px-4 py-2 text-xs text-white/50">
+            Showing {shown.length} of {matches.length} — refine your search to narrow results.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -7,6 +7,7 @@ import { usePresetStore } from '../stores/presetStore';
 import VisualizerTransport from '../components/visualizer/VisualizerTransport';
 import VisualizerHud from '../components/visualizer/VisualizerHud';
 import ParticleOverlay from '../components/visualizer/ParticleOverlay';
+import PresetSearch from '../components/visualizer/PresetSearch';
 import { useMediaQuery } from '../hooks/useMediaQuery';
 import { shouldCrossfade, captureSnapshot } from '../utils/presetCrossfade';
 import type { PresetIndexEntry } from '../types/presets';
@@ -319,6 +320,8 @@ export default function VisualizerScreen() {
   // Which Milkdrop engine is active: 'projectm' (WebGPU) or 'butterchurn'
   // (fallback), decided when milkdrop mode activates.
   const [milkdropEngine, setMilkdropEngine] = useState<'projectm' | 'butterchurn' | null>(null);
+  // Preset search/jump overlay (milkdrop only — opened with '/' or the HUD button).
+  const [presetSearchOpen, setPresetSearchOpen] = useState(false);
 
   const overlayTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -834,6 +837,19 @@ export default function VisualizerScreen() {
     };
   }, [milkdropPresetIndex, milkdropEngine, mode, runSnapshotFade]);
 
+  // Optional deep-link: `?preset=<name substring>` jumps to a matching preset
+  // once milkdrop is ready (handy for bug repros / sharing a specific preset).
+  // Read-only — it never writes the URL and only runs on first-ready.
+  useEffect(() => {
+    if (mode !== 'milkdrop' || !milkdropReady) return;
+    const q = new URLSearchParams(window.location.search).get('preset');
+    if (!q) return;
+    const idx = milkdropPresetNames.findIndex((n) => n.toLowerCase().includes(q.toLowerCase()));
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot deep-link jump on ready
+    if (idx >= 0) setMilkdropPresetIndex(idx);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once when milkdrop becomes ready
+  }, [milkdropReady, mode]);
+
   // Auto-hide overlay
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- show overlay on mount
@@ -914,6 +930,13 @@ export default function VisualizerScreen() {
         case 'k': case 'K': toggleFreeze(); break;
         case '.': stepFrame(); break;
         case 'f': case 'F': toggleFps(); break;
+        case '/':
+          if (mode === 'milkdrop' && milkdropReady) {
+            e.preventDefault();
+            setPresetSearchOpen(true);
+            resetOverlayTimer();
+          }
+          break;
         default: break;
       }
     };
@@ -1141,6 +1164,9 @@ export default function VisualizerScreen() {
         {/* Milkdrop control bar — shifts up when the transport occupies the bottom */}
         {mode === 'milkdrop' && milkdropReady && (
           <div className={`pointer-events-auto absolute left-1/2 flex -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-full bg-black/60 px-3 py-2 ${transportVisible ? 'bottom-28' : 'bottom-6'}`}>
+            <button onClick={(e) => { e.stopPropagation(); setPresetSearchOpen(true); resetOverlayTimer(); }} title="Search presets (/)" className={ctrlBtn(presetSearchOpen)}>
+              🔍 Find
+            </button>
             <button onClick={(e) => { e.stopPropagation(); toggleFreeze(); }} title="Freeze / unfreeze (K)" className={ctrlBtn(frozen)}>
               {frozen ? '▶ Resume' : '⏸ Freeze'}
             </button>
@@ -1203,6 +1229,20 @@ export default function VisualizerScreen() {
       >
         {toastText}
       </div>
+
+      {/* Preset search/jump overlay — selecting a result sets the active index,
+          reusing the normal switch path (hard-cut / live crossfade / etc.). */}
+      {presetSearchOpen && (
+        <PresetSearch
+          names={milkdropPresetNames}
+          onSelect={(i) => {
+            setMilkdropPresetIndex(i);
+            resetOverlayTimer();
+            setPresetSearchOpen(false);
+          }}
+          onClose={() => setPresetSearchOpen(false)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Adds a **user-facing visualizer preset search/jump overlay** — directly addresses how painful exact preset selection has been (10,343 presets, only `n`/`p`/random before).

## What it does
- Opens via **`/`** or a visible **🔍 Find** button in the milkdrop control bar (mouse/touch/mobile).
- **Fuzzy-filters** the active engine's preset names (`fuzzySearch.ts`); results as a labeled listbox with ↑/↓ + Enter, click/tap, Esc to close.
- **Capped at 50 rows** + a "Showing 50 of N — refine your search" hint (no 10k DOM nodes).
- Selecting a result maps back to the **original index** and calls `setMilkdropPresetIndex(originalIndex)` — **reusing the existing preset-switch path**, so all transition behavior is preserved with no new rendering logic:
  - hard-cut · live engine crossfade (`fade`) · reduced-motion suppression · butterchurn · feedback presets · auto-advance.
- Adds a **read-only `?preset=<substring>` deep-link** (jumps on first milkdrop-ready; never writes the URL; no preset text fetched).

## Scope
- New: `src/components/visualizer/PresetSearch.tsx` (+ tests). Wiring: `src/screens/VisualizerScreen.tsx`.
- **No** rendering/engine/crossfade changes, **no** preset-bundle changes, **no** dependency changes, **no** release-metadata changes, no command-palette refactor.
- **Category display intentionally deferred** (engine-asymmetric — projectM has categories, butterchurn names don't).

## Validation
- `npm run lint` ✅ · `npm run test:run` ✅ **191/191** (+5 new PresetSearch tests: capped-results+hint, click→original index, no-match, ArrowDown+Enter→original index, Esc closes) · `npm run build` ✅ · `npm run test:smoke` ✅ (0 console errors).
- **projectM/WebGPU (headed real Chrome):** `/` opens + autofocus; typing filters; select changes preset; under `fade` the jump uses the **engine crossfade** (`transition_to_preset` ×1, `load_preset` ×0); broad search caps at 50 + refine hint; 🔍 Find button opens it; Esc closes; next/prev still work; **0 console errors**.
- **Forced butterchurn (headed real Chrome):** with `force_butterchurn` on (no projectM created), search filtered the butterchurn set (91 matches, not 9k), selecting `"Aderrasi - Potion of Spirits"` changed the preset, next still works, **0 console errors**.

No engine/bundle/dependency/release changes; this is `develop`-only until you choose to ship it (e.g. a future beta.8).