### PR TITLE
Prepare v1.9.0-beta.8 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.8] - 2026-06-21
+
+### Added
+- **Visualizer preset search** — find and jump to a Milkdrop preset by name. Open it with the `/` shortcut or the **🔍 Find** button in the visualizer controls; fuzzy-filters the active engine's preset list (projectM/WebGPU or butterchurn), with results capped for performance and a "refine your search" hint when there are more matches.
+- **Read-only `?preset=` deep-link** — opening the visualizer with `?preset=<name>` jumps to the first matching preset (handy for sharing / bug reports). It never rewrites the URL.
+
+### Notes
+- Selecting a search result reuses the existing preset-switch path, so **hard-cut, live engine crossfade (`fade`), reduced-motion suppression, and butterchurn behavior are all preserved** unchanged.
+- No rendering, engine, preset-bundle, dependency, workflow, or Dockerfile changes.
+
 ## [1.9.0-beta.7] - 2026-06-21
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.7",
+  "version": "1.9.0-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.7",
+      "version": "1.9.0-beta.8",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.7",
+  "version": "1.9.0-beta.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.7</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.8</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">


### PR DESCRIPTION
Release-metadata prep for **v1.9.0-beta.8**. Metadata only — no code/behavior changes.

## Version bump
`1.9.0-beta.7` → `1.9.0-beta.8` in `package.json`, `package-lock.json` (root + `packages[""]` only — no dependency changes), and `src/screens/SettingsScreen.tsx` (About → `Vibrdrome Web v1.9.0-beta.8`).

## CHANGELOG — new `## [1.9.0-beta.8] - 2026-06-21`
- **Added:** user-facing **visualizer preset search** — `/` shortcut + **🔍 Find** button, fuzzy-filters the active engine's preset list (projectM/WebGPU or butterchurn), results capped for performance with a refine hint.
- **Added:** read-only **`?preset=` deep-link**.
- **Notes:** selecting a result reuses the existing preset-switch path, so hard-cut / live fade / reduced-motion / butterchurn behavior is preserved; no rendering/engine/preset-bundle/dependency/workflow/Dockerfile changes.

## Scope / guardrails
- beta.8 payload is exactly **PR #59** (already on `develop`); this PR adds only version metadata + CHANGELOG.
- No favorites (future feature). No dependency, Dockerfile, or workflow changes. No `master`, tag, GitHub Release, or deploy — targets `develop` only.

## Validation
`npm run lint` ✅ · `npm run test:run` ✅ 191/191 · `npm run build` ✅ · `npm run test:smoke` ✅ (0 console errors).