### PR TITLE
Release v1.9.0-beta.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.8] - 2026-06-21
+
+### Added
+- **Visualizer preset search** — find and jump to a Milkdrop preset by name. Open it with the `/` shortcut or the **🔍 Find** button in the visualizer controls; fuzzy-filters the active engine's preset list (projectM/WebGPU or butterchurn), with results capped for performance and a "refine your search" hint when there are more matches.
+- **Read-only `?preset=` deep-link** — opening the visualizer with `?preset=<name>` jumps to the first matching preset (handy for sharing / bug reports). It never rewrites the URL.
+
+### Notes
+- Selecting a search result reuses the existing preset-switch path, so **hard-cut, live engine crossfade (`fade`), reduced-motion suppression, and butterchurn behavior are all preserved** unchanged.
+- No rendering, engine, preset-bundle, dependency, workflow, or Dockerfile changes.
+
 ## [1.9.0-beta.7] - 2026-06-21
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.7",
+  "version": "1.9.0-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.7",
+      "version": "1.9.0-beta.8",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.7",
+  "version": "1.9.0-beta.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/visualizer/PresetSearch.test.tsx
+++ b/src/components/visualizer/PresetSearch.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PresetSearch from './PresetSearch';
+
+const NAMES = ['Alpha Bloom', 'Beta Wave', 'Gamma Spiral', 'Zebra Target'];
+
+describe('PresetSearch', () => {
+  it('caps rendered results and shows a refine hint when there are more matches', () => {
+    const many = Array.from({ length: 120 }, (_, i) => `Preset ${i}`);
+    render(<PresetSearch names={many} onSelect={() => {}} onClose={() => {}} />);
+    // Empty query lists all, but only the first 50 rows are rendered.
+    expect(screen.getAllByRole('option')).toHaveLength(50);
+    expect(screen.getByText(/Showing 50 of 120/)).toBeInTheDocument();
+  });
+
+  it('maps a fuzzy-sorted result back to its ORIGINAL index on click', () => {
+    const onSelect = vi.fn();
+    render(<PresetSearch names={NAMES} onSelect={onSelect} onClose={() => {}} />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'zebra' } });
+    fireEvent.click(screen.getByText('Zebra Target'));
+    expect(onSelect).toHaveBeenCalledWith(3); // original index in NAMES, not the filtered position
+  });
+
+  it('shows a no-match state', () => {
+    render(<PresetSearch names={NAMES} onSelect={() => {}} onClose={() => {}} />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'qqqzzz-nomatch' } });
+    expect(screen.getByText('No matching presets')).toBeInTheDocument();
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
+  });
+
+  it('selects the highlighted result with ArrowDown + Enter (original index)', () => {
+    const onSelect = vi.fn();
+    render(<PresetSearch names={NAMES} onSelect={onSelect} onClose={() => {}} />);
+    const input = screen.getByRole('textbox');
+    // 'a' matches several; highlight starts at 0, ArrowDown moves to the 2nd row.
+    fireEvent.change(input, { target: { value: 'a' } });
+    const options = screen.getAllByRole('option');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    // The 2nd visible row's text maps back to its original index in NAMES.
+    const chosenName = options[1].textContent ?? '';
+    expect(onSelect).toHaveBeenCalledWith(NAMES.indexOf(chosenName));
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(<PresetSearch names={NAMES} onSelect={() => {}} onClose={onClose} />);
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/visualizer/PresetSearch.tsx
+++ b/src/components/visualizer/PresetSearch.tsx
@@ -1,0 +1,141 @@
+// Visualizer-scoped preset search overlay. Filters the active engine's preset
+// name list and, on select, jumps by ORIGINAL index — the caller wires that to
+// the existing `setActiveIndex` preset-switch path, so all transition behaviour
+// (hard-cut / live crossfade / reduced-motion / butterchurn) is preserved with
+// no new rendering logic. Search is name-only (no preset text is loaded).
+//
+// Mounted only while open (the parent conditionally renders it), so it starts
+// with fresh state and an autofocused input each time.
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { fuzzyFilter } from '../../utils/fuzzySearch';
+
+const MAX_RESULTS = 50;
+
+interface PresetSearchProps {
+  /** Active engine's selectable preset names (projectM or butterchurn). */
+  names: string[];
+  /** Called with the ORIGINAL index into `names` for the chosen preset. */
+  onSelect: (index: number) => void;
+  onClose: () => void;
+}
+
+export default function PresetSearch({ names, onSelect, onClose }: PresetSearchProps) {
+  const [query, setQuery] = useState('');
+  const [highlight, setHighlight] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  // Pair each name with its original index so a fuzzy-sorted result still maps
+  // back to the correct preset index.
+  const items = useMemo(() => names.map((name, index) => ({ name, index })), [names]);
+  const matches = useMemo(() => fuzzyFilter(items, query, (i) => i.name), [items, query]);
+  const shown = matches.slice(0, MAX_RESULTS);
+  const overflow = matches.length - shown.length;
+
+  // Autofocus the input on mount.
+  useEffect(() => {
+    const id = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  // Keep the highlighted row scrolled into view (no state change here).
+  useEffect(() => {
+    (listRef.current?.children[highlight] as HTMLElement | undefined)?.scrollIntoView?.({ block: 'nearest' });
+  }, [highlight]);
+
+  const choose = (i: number) => {
+    const m = shown[i];
+    if (m) onSelect(m.index);
+  };
+
+  // Handle keys at the overlay level and stop propagation so the visualizer's
+  // global shortcuts never fire while searching. Printable keys fall through to
+  // the input (only navigation keys are intercepted).
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    e.stopPropagation();
+    switch (e.key) {
+      case 'Escape':
+        e.preventDefault();
+        onClose();
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        setHighlight((h) => Math.min(h + 1, shown.length - 1));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setHighlight((h) => Math.max(h - 1, 0));
+        break;
+      case 'Enter':
+        e.preventDefault();
+        choose(highlight);
+        break;
+      case 'Tab':
+        // Trap focus inside the overlay.
+        e.preventDefault();
+        inputRef.current?.focus();
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div
+      className="absolute inset-0 z-30 flex items-start justify-center bg-black/60 p-4 pt-16"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        className="w-full max-w-lg overflow-hidden rounded-lg border border-white/10 bg-bg-secondary shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={onKeyDown}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search presets"
+      >
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setHighlight(0);
+          }}
+          placeholder={`Search ${names.length} presets…`}
+          aria-label="Search presets"
+          className="w-full bg-transparent px-4 py-3 text-sm text-white outline-none placeholder:text-white/40"
+        />
+        <ul
+          ref={listRef}
+          className="max-h-80 overflow-y-auto border-t border-white/10"
+          role="listbox"
+          aria-label="Preset results"
+        >
+          {shown.length === 0 ? (
+            <li className="px-4 py-3 text-sm text-white/50">No matching presets</li>
+          ) : (
+            shown.map((m, i) => (
+              <li
+                key={m.index}
+                role="option"
+                aria-selected={i === highlight}
+                onClick={() => choose(i)}
+                onMouseMove={() => setHighlight(i)}
+                className={`cursor-pointer truncate px-4 py-2 text-sm ${
+                  i === highlight ? 'bg-white/15 text-white' : 'text-white/80'
+                }`}
+              >
+                {m.name}
+              </li>
+            ))
+          )}
+        </ul>
+        {overflow > 0 && (
+          <div className="border-t border-white/10 px-4 py-2 text-xs text-white/50">
+            Showing {shown.length} of {matches.length} — refine your search to narrow results.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.7</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.8</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -7,6 +7,7 @@ import { usePresetStore } from '../stores/presetStore';
 import VisualizerTransport from '../components/visualizer/VisualizerTransport';
 import VisualizerHud from '../components/visualizer/VisualizerHud';
 import ParticleOverlay from '../components/visualizer/ParticleOverlay';
+import PresetSearch from '../components/visualizer/PresetSearch';
 import { useMediaQuery } from '../hooks/useMediaQuery';
 import { shouldCrossfade, captureSnapshot } from '../utils/presetCrossfade';
 import type { PresetIndexEntry } from '../types/presets';
@@ -319,6 +320,8 @@ export default function VisualizerScreen() {
   // Which Milkdrop engine is active: 'projectm' (WebGPU) or 'butterchurn'
   // (fallback), decided when milkdrop mode activates.
   const [milkdropEngine, setMilkdropEngine] = useState<'projectm' | 'butterchurn' | null>(null);
+  // Preset search/jump overlay (milkdrop only — opened with '/' or the HUD button).
+  const [presetSearchOpen, setPresetSearchOpen] = useState(false);
 
   const overlayTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -834,6 +837,19 @@ export default function VisualizerScreen() {
     };
   }, [milkdropPresetIndex, milkdropEngine, mode, runSnapshotFade]);
 
+  // Optional deep-link: `?preset=<name substring>` jumps to a matching preset
+  // once milkdrop is ready (handy for bug repros / sharing a specific preset).
+  // Read-only — it never writes the URL and only runs on first-ready.
+  useEffect(() => {
+    if (mode !== 'milkdrop' || !milkdropReady) return;
+    const q = new URLSearchParams(window.location.search).get('preset');
+    if (!q) return;
+    const idx = milkdropPresetNames.findIndex((n) => n.toLowerCase().includes(q.toLowerCase()));
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot deep-link jump on ready
+    if (idx >= 0) setMilkdropPresetIndex(idx);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once when milkdrop becomes ready
+  }, [milkdropReady, mode]);
+
   // Auto-hide overlay
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- show overlay on mount
@@ -914,6 +930,13 @@ export default function VisualizerScreen() {
         case 'k': case 'K': toggleFreeze(); break;
         case '.': stepFrame(); break;
         case 'f': case 'F': toggleFps(); break;
+        case '/':
+          if (mode === 'milkdrop' && milkdropReady) {
+            e.preventDefault();
+            setPresetSearchOpen(true);
+            resetOverlayTimer();
+          }
+          break;
         default: break;
       }
     };
@@ -1141,6 +1164,9 @@ export default function VisualizerScreen() {
         {/* Milkdrop control bar — shifts up when the transport occupies the bottom */}
         {mode === 'milkdrop' && milkdropReady && (
           <div className={`pointer-events-auto absolute left-1/2 flex -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-full bg-black/60 px-3 py-2 ${transportVisible ? 'bottom-28' : 'bottom-6'}`}>
+            <button onClick={(e) => { e.stopPropagation(); setPresetSearchOpen(true); resetOverlayTimer(); }} title="Search presets (/)" className={ctrlBtn(presetSearchOpen)}>
+              🔍 Find
+            </button>
             <button onClick={(e) => { e.stopPropagation(); toggleFreeze(); }} title="Freeze / unfreeze (K)" className={ctrlBtn(frozen)}>
               {frozen ? '▶ Resume' : '⏸ Freeze'}
             </button>
@@ -1203,6 +1229,20 @@ export default function VisualizerScreen() {
       >
         {toastText}
       </div>
+
+      {/* Preset search/jump overlay — selecting a result sets the active index,
+          reusing the normal switch path (hard-cut / live crossfade / etc.). */}
+      {presetSearchOpen && (
+        <PresetSearch
+          names={milkdropPresetNames}
+          onSelect={(i) => {
+            setMilkdropPresetIndex(i);
+            resetOverlayTimer();
+            setPresetSearchOpen(false);
+          }}
+          onClose={() => setPresetSearchOpen(false)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Promote `develop` → `master` for **v1.9.0-beta.8**. Ships the user-facing visualizer preset search. Production remains **v1.9.0-beta.7** until this PR is merged.

## Included
**1. Visualizer preset search (PR #59)**
- `/` keyboard shortcut + **🔍 Find** button.
- Fuzzy search over the active engine's preset list (projectM/WebGPU or butterchurn).
- Results capped (50) with a "refine your search" hint.
- Result selection reuses the existing preset-index switch path (`setMilkdropPresetIndex`).
- Read-only **`?preset=`** deep-link support.

**2. Release metadata (PR #60)**
- Version bumped to `1.9.0-beta.8`; About string updated; CHANGELOG entry added.

## Behavior preserved
hard-cut · live fade/crossfade · reduced-motion suppression · butterchurn · next/previous/random · auto-advance — all reuse the existing switch path, unchanged.

## Excluded
No favorites. No rendering/engine/preset-bundle/dependency/workflow/Dockerfile changes. No projectM-rs changes.

## Validation
- PR #59: 191 tests; projectM/WebGPU manual check; **forced-butterchurn** manual check; 0 console errors.
- PR #60: metadata-only; CI green.
- This PR's CI runs fresh below.

## Queued commits (`master..develop`)
- PR #60 — `v1.9.0-beta.8` metadata
- PR #59 — visualizer preset search

> On merge, the **Deploy** workflow publishes to production (Cloudflare Pages + Docker Hub on `wrangler-action@v4`). The GitHub prerelease for `v1.9.0-beta.8` is created by the **Release** workflow when the `v1.9.0-beta.8` tag is pushed (a manual step after merge).