### PR TITLE
Prepare v1.9.0-beta.9 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.9] - 2026-06-21
+
+### Added
+- **Visualizer preset favorites** (local-only) — save the presets you like and jump back to them.
+- ☆/★ **favorite toggle for the current preset** in the visualizer controls.
+- **Per-row favorite stars** inside preset search.
+- A **Favorites filter** inside preset search to show only favorited presets.
+
+### Notes
+- Favorites are stored **locally** in a versioned `localStorage` blob; bad/old data degrades safely to empty.
+- Identity: projectM favorites use the stable preset **path**; butterchurn favorites use the engine-prefixed preset **name**.
+- Selecting a favorite reuses the existing preset-switch path, so hard-cut / live crossfade / reduced-motion / butterchurn / next-prev-random / auto-advance behavior is unchanged.
+- No rendering, engine, crossfade, preset-bundle, dependency, workflow, or Dockerfile changes.
+- Deferred (not in this release): HUD ★ indicator beside the preset name, a favoriting keyboard shortcut, favorites-only random/auto-advance, orphaned-favorite cleanup, and cross-device sync.
+
 ## [1.9.0-beta.8] - 2026-06-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.8",
+  "version": "1.9.0-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.8",
+      "version": "1.9.0-beta.9",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.8",
+  "version": "1.9.0-beta.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.8</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.9</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">


### PR DESCRIPTION
Release-metadata prep for **v1.9.0-beta.9**. Metadata only — no code/behavior changes.

## Version bump
`1.9.0-beta.8` → `1.9.0-beta.9` in `package.json`, `package-lock.json` (root + `packages[""]` only — no dependency changes), and `src/screens/SettingsScreen.tsx` (About → `Vibrdrome Web v1.9.0-beta.9`).

## CHANGELOG — new `## [1.9.0-beta.9] - 2026-06-21`
- **Added:** local-only **visualizer preset favorites** — current-preset ☆/★ toggle, per-row stars in preset search, and a Favorites filter.
- **Notes:** favorites stored in versioned `localStorage` (degrades safely); projectM keys on stable **path**, butterchurn on engine-prefixed **name**; selecting a favorite reuses the existing preset-switch path → hard-cut / live crossfade / reduced-motion / butterchurn / next-prev-random / auto-advance unchanged; no rendering/engine/crossfade/preset-bundle/dependency/workflow/Dockerfile changes.
- **Deferred:** HUD ★ indicator, favoriting keyboard shortcut, favorites-only random/auto-advance, orphan cleanup, sync.

## Scope / guardrails
- beta.9 payload is exactly **PR #62** (already on `develop`); this PR adds only version metadata + CHANGELOG.
- No dependency, Dockerfile, workflow, engine, or projectM changes. No `master`, tag, GitHub Release, or deploy — targets `develop` only.

## Validation
`npm run lint` ✅ · `npm run test:run` ✅ 205/205 · `npm run build` ✅ · `npm run test:smoke` ✅ (0 console errors).