### PR TITLE
Release v1.9.0-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.9] - 2026-06-21
+
+### Added
+- **Visualizer preset favorites** (local-only) — save the presets you like and jump back to them.
+- ☆/★ **favorite toggle for the current preset** in the visualizer controls.
+- **Per-row favorite stars** inside preset search.
+- A **Favorites filter** inside preset search to show only favorited presets.
+
+### Notes
+- Favorites are stored **locally** in a versioned `localStorage` blob; bad/old data degrades safely to empty.
+- Identity: projectM favorites use the stable preset **path**; butterchurn favorites use the engine-prefixed preset **name**.
+- Selecting a favorite reuses the existing preset-switch path, so hard-cut / live crossfade / reduced-motion / butterchurn / next-prev-random / auto-advance behavior is unchanged.
+- No rendering, engine, crossfade, preset-bundle, dependency, workflow, or Dockerfile changes.
+- Deferred (not in this release): HUD ★ indicator beside the preset name, a favoriting keyboard shortcut, favorites-only random/auto-advance, orphaned-favorite cleanup, and cross-device sync.
+
 ## [1.9.0-beta.8] - 2026-06-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.8",
+  "version": "1.9.0-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.8",
+      "version": "1.9.0-beta.9",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.8",
+  "version": "1.9.0-beta.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/visualizer/PresetSearch.test.tsx
+++ b/src/components/visualizer/PresetSearch.test.tsx
@@ -4,25 +4,38 @@ import PresetSearch from './PresetSearch';
 
 const NAMES = ['Alpha Bloom', 'Beta Wave', 'Gamma Spiral', 'Zebra Target'];
 
+// Render helper that fills in favorites props (index-based keys) with overrides.
+function renderSearch(over: Partial<React.ComponentProps<typeof PresetSearch>> = {}) {
+  const props: React.ComponentProps<typeof PresetSearch> = {
+    names: NAMES,
+    favoriteKeys: new Set<string>(),
+    favoriteKeyForIndex: (i: number) => `fav:${i}`,
+    onToggleFavorite: () => {},
+    onSelect: () => {},
+    onClose: () => {},
+    ...over,
+  };
+  return render(<PresetSearch {...props} />);
+}
+
 describe('PresetSearch', () => {
   it('caps rendered results and shows a refine hint when there are more matches', () => {
     const many = Array.from({ length: 120 }, (_, i) => `Preset ${i}`);
-    render(<PresetSearch names={many} onSelect={() => {}} onClose={() => {}} />);
-    // Empty query lists all, but only the first 50 rows are rendered.
+    renderSearch({ names: many });
     expect(screen.getAllByRole('option')).toHaveLength(50);
     expect(screen.getByText(/Showing 50 of 120/)).toBeInTheDocument();
   });
 
   it('maps a fuzzy-sorted result back to its ORIGINAL index on click', () => {
     const onSelect = vi.fn();
-    render(<PresetSearch names={NAMES} onSelect={onSelect} onClose={() => {}} />);
+    renderSearch({ onSelect });
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'zebra' } });
     fireEvent.click(screen.getByText('Zebra Target'));
-    expect(onSelect).toHaveBeenCalledWith(3); // original index in NAMES, not the filtered position
+    expect(onSelect).toHaveBeenCalledWith(3);
   });
 
   it('shows a no-match state', () => {
-    render(<PresetSearch names={NAMES} onSelect={() => {}} onClose={() => {}} />);
+    renderSearch();
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'qqqzzz-nomatch' } });
     expect(screen.getByText('No matching presets')).toBeInTheDocument();
     expect(screen.queryAllByRole('option')).toHaveLength(0);
@@ -30,22 +43,58 @@ describe('PresetSearch', () => {
 
   it('selects the highlighted result with ArrowDown + Enter (original index)', () => {
     const onSelect = vi.fn();
-    render(<PresetSearch names={NAMES} onSelect={onSelect} onClose={() => {}} />);
+    renderSearch({ onSelect });
     const input = screen.getByRole('textbox');
-    // 'a' matches several; highlight starts at 0, ArrowDown moves to the 2nd row.
     fireEvent.change(input, { target: { value: 'a' } });
     const options = screen.getAllByRole('option');
     fireEvent.keyDown(input, { key: 'ArrowDown' });
     fireEvent.keyDown(input, { key: 'Enter' });
-    // The 2nd visible row's text maps back to its original index in NAMES.
     const chosenName = options[1].textContent ?? '';
-    expect(onSelect).toHaveBeenCalledWith(NAMES.indexOf(chosenName));
+    // textContent includes the star glyph; match the name prefix back to NAMES.
+    const idx = NAMES.findIndex((n) => chosenName.startsWith(n));
+    expect(onSelect).toHaveBeenCalledWith(idx);
   });
 
   it('closes on Escape', () => {
     const onClose = vi.fn();
-    render(<PresetSearch names={NAMES} onSelect={() => {}} onClose={onClose} />);
+    renderSearch({ onClose });
     fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
     expect(onClose).toHaveBeenCalled();
+  });
+
+  // --- favorites ---
+
+  it('a row star toggles the correct key and does NOT select the row', () => {
+    const onToggleFavorite = vi.fn();
+    const onSelect = vi.fn();
+    renderSearch({ onToggleFavorite, onSelect });
+    // Empty query lists all in order; row 0 = Alpha Bloom (original index 0).
+    const star = screen.getAllByLabelText('Favorite preset')[0];
+    fireEvent.click(star);
+    expect(onToggleFavorite).toHaveBeenCalledWith('fav:0');
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('reflects favorited state (filled star + Unfavorite label)', () => {
+    renderSearch({ favoriteKeys: new Set(['fav:2']) });
+    // Exactly one row is favorited → one "Unfavorite preset" button.
+    expect(screen.getAllByLabelText('Unfavorite preset')).toHaveLength(1);
+  });
+
+  it('Favorites filter shows only favorited rows, and selecting returns the original index', () => {
+    const onSelect = vi.fn();
+    renderSearch({ favoriteKeys: new Set(['fav:2']), onSelect });
+    fireEvent.click(screen.getByLabelText('Show favorites only'));
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0].textContent).toMatch(/Gamma Spiral/);
+    fireEvent.click(options[0]);
+    expect(onSelect).toHaveBeenCalledWith(2); // original index, not filtered position
+  });
+
+  it('Favorites filter with no favorites shows an empty favorites state', () => {
+    renderSearch({ favoriteKeys: new Set() });
+    fireEvent.click(screen.getByLabelText('Show favorites only'));
+    expect(screen.getByText('No favorited presets yet')).toBeInTheDocument();
   });
 });

--- a/src/components/visualizer/PresetSearch.tsx
+++ b/src/components/visualizer/PresetSearch.tsx
@@ -4,6 +4,9 @@
 // (hard-cut / live crossfade / reduced-motion / butterchurn) is preserved with
 // no new rendering logic. Search is name-only (no preset text is loaded).
 //
+// Rows can be favorited (per-engine, persisted by the caller's store) and an
+// optional Favorites filter narrows the list to favorited presets.
+//
 // Mounted only while open (the parent conditionally renders it), so it starts
 // with fresh state and an autofocused input each time.
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -14,23 +17,53 @@ const MAX_RESULTS = 50;
 interface PresetSearchProps {
   /** Active engine's selectable preset names (projectM or butterchurn). */
   names: string[];
+  /** Currently-favorited keys (engine-prefixed); used for star state + filter. */
+  favoriteKeys: Set<string>;
+  /** Resolve the favorite key for an active-list index (null if unresolvable). */
+  favoriteKeyForIndex: (index: number) => string | null;
+  /** Toggle the favorite for a given key. */
+  onToggleFavorite: (key: string) => void;
   /** Called with the ORIGINAL index into `names` for the chosen preset. */
   onSelect: (index: number) => void;
   onClose: () => void;
 }
 
-export default function PresetSearch({ names, onSelect, onClose }: PresetSearchProps) {
+export default function PresetSearch({
+  names,
+  favoriteKeys,
+  favoriteKeyForIndex,
+  onToggleFavorite,
+  onSelect,
+  onClose,
+}: PresetSearchProps) {
   const [query, setQuery] = useState('');
   const [highlight, setHighlight] = useState(0);
+  const [favoritesOnly, setFavoritesOnly] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
 
   // Pair each name with its original index so a fuzzy-sorted result still maps
   // back to the correct preset index.
   const items = useMemo(() => names.map((name, index) => ({ name, index })), [names]);
-  const matches = useMemo(() => fuzzyFilter(items, query, (i) => i.name), [items, query]);
+  // Favorites filter narrows the candidate list *before* text filtering.
+  const base = useMemo(
+    () =>
+      favoritesOnly
+        ? items.filter((it) => {
+            const k = favoriteKeyForIndex(it.index);
+            return k != null && favoriteKeys.has(k);
+          })
+        : items,
+    [items, favoritesOnly, favoriteKeys, favoriteKeyForIndex],
+  );
+  const matches = useMemo(() => fuzzyFilter(base, query, (i) => i.name), [base, query]);
   const shown = matches.slice(0, MAX_RESULTS);
   const overflow = matches.length - shown.length;
+
+  const isFav = (index: number) => {
+    const k = favoriteKeyForIndex(index);
+    return k != null && favoriteKeys.has(k);
+  };
 
   // Autofocus the input on mount.
   useEffect(() => {
@@ -46,6 +79,11 @@ export default function PresetSearch({ names, onSelect, onClose }: PresetSearchP
   const choose = (i: number) => {
     const m = shown[i];
     if (m) onSelect(m.index);
+  };
+
+  const toggleRowFavorite = (index: number) => {
+    const k = favoriteKeyForIndex(index);
+    if (k) onToggleFavorite(k);
   };
 
   // Handle keys at the overlay level and stop propagation so the visualizer's
@@ -94,40 +132,77 @@ export default function PresetSearch({ names, onSelect, onClose }: PresetSearchP
         aria-modal="true"
         aria-label="Search presets"
       >
-        <input
-          ref={inputRef}
-          value={query}
-          onChange={(e) => {
-            setQuery(e.target.value);
-            setHighlight(0);
-          }}
-          placeholder={`Search ${names.length} presets…`}
-          aria-label="Search presets"
-          className="w-full bg-transparent px-4 py-3 text-sm text-white outline-none placeholder:text-white/40"
-        />
+        <div className="flex items-center border-b border-white/10">
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setHighlight(0);
+            }}
+            placeholder={`Search ${names.length} presets…`}
+            aria-label="Search presets"
+            className="min-w-0 flex-1 bg-transparent px-4 py-3 text-sm text-white outline-none placeholder:text-white/40"
+          />
+          <button
+            type="button"
+            onClick={() => {
+              setFavoritesOnly((v) => !v);
+              setHighlight(0);
+            }}
+            aria-pressed={favoritesOnly}
+            aria-label="Show favorites only"
+            title="Show favorites only"
+            className={`mr-2 shrink-0 rounded-full px-3 py-1 text-xs ${
+              favoritesOnly ? 'bg-accent/30 text-white' : 'bg-white/10 text-white/70 hover:text-white'
+            }`}
+          >
+            ★ Favorites
+          </button>
+        </div>
         <ul
           ref={listRef}
-          className="max-h-80 overflow-y-auto border-t border-white/10"
+          className="max-h-80 overflow-y-auto"
           role="listbox"
           aria-label="Preset results"
         >
           {shown.length === 0 ? (
-            <li className="px-4 py-3 text-sm text-white/50">No matching presets</li>
+            <li className="px-4 py-3 text-sm text-white/50">
+              {favoritesOnly ? 'No favorited presets yet' : 'No matching presets'}
+            </li>
           ) : (
-            shown.map((m, i) => (
-              <li
-                key={m.index}
-                role="option"
-                aria-selected={i === highlight}
-                onClick={() => choose(i)}
-                onMouseMove={() => setHighlight(i)}
-                className={`cursor-pointer truncate px-4 py-2 text-sm ${
-                  i === highlight ? 'bg-white/15 text-white' : 'text-white/80'
-                }`}
-              >
-                {m.name}
-              </li>
-            ))
+            shown.map((m, i) => {
+              const fav = isFav(m.index);
+              return (
+                <li
+                  key={m.index}
+                  role="option"
+                  aria-selected={i === highlight}
+                  onClick={() => choose(i)}
+                  onMouseMove={() => setHighlight(i)}
+                  className={`flex cursor-pointer items-center gap-2 px-4 py-2 text-sm ${
+                    i === highlight ? 'bg-white/15 text-white' : 'text-white/80'
+                  }`}
+                >
+                  <span className="min-w-0 flex-1 truncate">{m.name}</span>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleRowFavorite(m.index);
+                    }}
+                    aria-label={fav ? 'Unfavorite preset' : 'Favorite preset'}
+                    aria-pressed={fav}
+                    title={fav ? 'Unfavorite preset' : 'Favorite preset'}
+                    className={`shrink-0 rounded px-1 text-base leading-none ${
+                      fav ? 'text-yellow-300' : 'text-white/30 hover:text-white/70'
+                    }`}
+                  >
+                    {fav ? '★' : '☆'}
+                  </button>
+                </li>
+              );
+            })
           )}
         </ul>
         {overflow > 0 && (

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.8</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.9</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -10,6 +10,8 @@ import ParticleOverlay from '../components/visualizer/ParticleOverlay';
 import PresetSearch from '../components/visualizer/PresetSearch';
 import { useMediaQuery } from '../hooks/useMediaQuery';
 import { shouldCrossfade, captureSnapshot } from '../utils/presetCrossfade';
+import { usePresetFavoritesStore } from '../stores/presetFavoritesStore';
+import { favoriteKeyForIndex as resolveFavoriteKey } from '../utils/presetFavorites';
 import type { PresetIndexEntry } from '../types/presets';
 
 // projectM preset category that is excluded from normal selection: these are
@@ -306,6 +308,10 @@ export default function VisualizerScreen() {
   const [presetIndex, setPresetIndex] = useState(0);
   const [milkdropPresetIndex, setMilkdropPresetIndex] = useState(0);
   const [milkdropPresetNames, setMilkdropPresetNames] = useState<string[]>([]);
+  // Render-reactive mirror of the projectM entries (paths) for the favorite-key
+  // resolver; the preset-switch effect still uses projectmEntriesRef (effect-time
+  // ref read). Empty for butterchurn (it keys favorites by name, not path).
+  const [milkdropEntries, setMilkdropEntries] = useState<PresetIndexEntry[]>([]);
   const [milkdropReady, setMilkdropReady] = useState(false);
   const [showOverlay, setShowOverlay] = useState(true);
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -322,6 +328,13 @@ export default function VisualizerScreen() {
   const [milkdropEngine, setMilkdropEngine] = useState<'projectm' | 'butterchurn' | null>(null);
   // Preset search/jump overlay (milkdrop only — opened with '/' or the HUD button).
   const [presetSearchOpen, setPresetSearchOpen] = useState(false);
+  // Local preset favorites (engine-prefixed keys; persisted to localStorage).
+  const favoriteKeys = usePresetFavoritesStore((s) => s.favoriteKeys);
+  const toggleFavorite = usePresetFavoritesStore((s) => s.toggleFavorite);
+  const favoriteKeyForIndex = useCallback(
+    (index: number) => resolveFavoriteKey(milkdropEngine, index, milkdropEntries, milkdropPresetNames),
+    [milkdropEngine, milkdropEntries, milkdropPresetNames],
+  );
 
   const overlayTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -558,6 +571,7 @@ export default function VisualizerScreen() {
         const presetNames = Object.keys(presets).sort();
 
         setMilkdropPresetNames(presetNames);
+        setMilkdropEntries([]); // butterchurn keys favorites by name, not path
 
         const canvas = milkdropCanvasRef.current;
         if (!canvas) return;
@@ -688,7 +702,10 @@ export default function VisualizerScreen() {
       const entries = store.listPresets().filter((e) => e.category !== TRANSITION_CATEGORY);
       if (entries.length === 0) throw new Error('no selectable presets in manifest');
       projectmEntriesRef.current = entries;
-      if (!cancelled) setMilkdropPresetNames(entries.map((e) => e.name));
+      if (!cancelled) {
+        setMilkdropPresetNames(entries.map((e) => e.name));
+        setMilkdropEntries(entries);
+      }
 
       // Start on a RANDOM non-transition preset (index 0 is alphabetical — the
       // worst case, the "! Transition" black presets). Set the index so the
@@ -765,6 +782,7 @@ export default function VisualizerScreen() {
         pmEngineRef.current = null;
       }
       projectmEntriesRef.current = [];
+      setMilkdropEntries([]);
       setMilkdropReady(false);
     };
   }, [mode, milkdropEngine, tickFps]);
@@ -862,6 +880,10 @@ export default function VisualizerScreen() {
   const totalPresets = mode === 'shader' ? SHADER_PRESETS.length : milkdropPresetNames.length;
   const activeIndex = mode === 'shader' ? presetIndex : milkdropPresetIndex;
   const setActiveIndex = mode === 'shader' ? setPresetIndex : setMilkdropPresetIndex;
+
+  // Favorite state for the currently-active milkdrop preset (null in shader mode).
+  const currentFavoriteKey = favoriteKeyForIndex(milkdropPresetIndex);
+  const currentIsFavorite = currentFavoriteKey != null && favoriteKeys.has(currentFavoriteKey);
 
   const nextPreset = () => {
     setActiveIndex((i) => (i + 1) % totalPresets);
@@ -1167,6 +1189,16 @@ export default function VisualizerScreen() {
             <button onClick={(e) => { e.stopPropagation(); setPresetSearchOpen(true); resetOverlayTimer(); }} title="Search presets (/)" className={ctrlBtn(presetSearchOpen)}>
               🔍 Find
             </button>
+            <button
+              onClick={(e) => { e.stopPropagation(); if (currentFavoriteKey) toggleFavorite(currentFavoriteKey); resetOverlayTimer(); }}
+              disabled={!currentFavoriteKey}
+              title={currentIsFavorite ? 'Unfavorite this preset' : 'Favorite this preset'}
+              aria-label={currentIsFavorite ? 'Unfavorite preset' : 'Favorite preset'}
+              aria-pressed={currentIsFavorite}
+              className={ctrlBtn(currentIsFavorite, !currentFavoriteKey)}
+            >
+              {currentIsFavorite ? '★ Favorited' : '☆ Favorite'}
+            </button>
             <button onClick={(e) => { e.stopPropagation(); toggleFreeze(); }} title="Freeze / unfreeze (K)" className={ctrlBtn(frozen)}>
               {frozen ? '▶ Resume' : '⏸ Freeze'}
             </button>
@@ -1235,6 +1267,9 @@ export default function VisualizerScreen() {
       {presetSearchOpen && (
         <PresetSearch
           names={milkdropPresetNames}
+          favoriteKeys={favoriteKeys}
+          favoriteKeyForIndex={favoriteKeyForIndex}
+          onToggleFavorite={toggleFavorite}
           onSelect={(i) => {
             setMilkdropPresetIndex(i);
             resetOverlayTimer();

--- a/src/stores/presetFavoritesStore.test.ts
+++ b/src/stores/presetFavoritesStore.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { usePresetFavoritesStore, loadFavorites } from './presetFavoritesStore';
+
+const STORAGE_KEY = 'vibrdrome_visualizer_favorites';
+
+// Deterministic in-memory localStorage (the test env's built-in one is partial).
+beforeEach(() => {
+  const store: Record<string, string> = {};
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => {
+      store[k] = String(v);
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) delete store[k];
+    },
+  });
+  usePresetFavoritesStore.setState({ favoriteKeys: new Set() });
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe('presetFavoritesStore', () => {
+  it('toggles favorites correctly', () => {
+    const s = usePresetFavoritesStore.getState();
+    expect(s.isFavorite('projectm:a')).toBe(false);
+    s.toggleFavorite('projectm:a');
+    expect(usePresetFavoritesStore.getState().isFavorite('projectm:a')).toBe(true);
+    usePresetFavoritesStore.getState().toggleFavorite('projectm:a');
+    expect(usePresetFavoritesStore.getState().isFavorite('projectm:a')).toBe(false);
+  });
+
+  it('add/remove are idempotent', () => {
+    const s = usePresetFavoritesStore.getState();
+    s.addFavorite('butterchurn:x');
+    s.addFavorite('butterchurn:x');
+    expect(usePresetFavoritesStore.getState().favoriteKeys.size).toBe(1);
+    usePresetFavoritesStore.getState().removeFavorite('butterchurn:x');
+    usePresetFavoritesStore.getState().removeFavorite('butterchurn:x');
+    expect(usePresetFavoritesStore.getState().favoriteKeys.size).toBe(0);
+  });
+
+  it('persists a versioned JSON blob to localStorage', () => {
+    usePresetFavoritesStore.getState().toggleFavorite('projectm:p/one.milk');
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw!)).toEqual({ v: 1, keys: ['projectm:p/one.milk'] });
+  });
+
+  it('loadFavorites reads a versioned JSON blob back into a Set', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ v: 1, keys: ['projectm:a', 'butterchurn:b'] }));
+    const set = loadFavorites();
+    expect(set.has('projectm:a')).toBe(true);
+    expect(set.has('butterchurn:b')).toBe(true);
+    expect(set.size).toBe(2);
+  });
+
+  it('degrades safely to empty for malformed / unknown blobs', () => {
+    localStorage.setItem(STORAGE_KEY, 'not json at all {{{');
+    expect(loadFavorites().size).toBe(0);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ nope: true }));
+    expect(loadFavorites().size).toBe(0);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ v: 1, keys: 'oops' }));
+    expect(loadFavorites().size).toBe(0);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ v: 1, keys: [1, 2, 'projectm:ok'] }));
+    expect(loadFavorites().size).toBe(1); // non-strings filtered out
+    expect(loadFavorites().has('projectm:ok')).toBe(true);
+  });
+});

--- a/src/stores/presetFavoritesStore.ts
+++ b/src/stores/presetFavoritesStore.ts
@@ -1,0 +1,64 @@
+// Local-only store of favorited visualizer presets (engine-prefixed keys; see
+// utils/presetFavorites). Persisted to localStorage as a versioned JSON blob so
+// the shape can evolve; malformed/old data degrades safely to an empty set.
+// Orphaned keys (preset no longer in the manifest) are kept stored — callers
+// just don't show what they can't resolve.
+import { create } from 'zustand';
+
+const STORAGE_KEY = 'vibrdrome_visualizer_favorites';
+const VERSION = 1;
+
+/** Load favorites from localStorage. Never throws; bad data → empty set. */
+export function loadFavorites(): Set<string> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || !Array.isArray((parsed as { keys?: unknown }).keys)) {
+      return new Set();
+    }
+    const keys = (parsed as { keys: unknown[] }).keys.filter((k): k is string => typeof k === 'string');
+    return new Set(keys);
+  } catch {
+    return new Set();
+  }
+}
+
+function persist(keys: Set<string>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ v: VERSION, keys: [...keys] }));
+  } catch {
+    /* ignore quota/availability errors */
+  }
+}
+
+interface PresetFavoritesState {
+  favoriteKeys: Set<string>;
+  isFavorite: (key: string) => boolean;
+  addFavorite: (key: string) => void;
+  removeFavorite: (key: string) => void;
+  toggleFavorite: (key: string) => void;
+}
+
+export const usePresetFavoritesStore = create<PresetFavoritesState>((set, get) => ({
+  favoriteKeys: loadFavorites(),
+  isFavorite: (key) => get().favoriteKeys.has(key),
+  addFavorite: (key) => {
+    if (get().favoriteKeys.has(key)) return;
+    const next = new Set(get().favoriteKeys);
+    next.add(key);
+    persist(next);
+    set({ favoriteKeys: next });
+  },
+  removeFavorite: (key) => {
+    if (!get().favoriteKeys.has(key)) return;
+    const next = new Set(get().favoriteKeys);
+    next.delete(key);
+    persist(next);
+    set({ favoriteKeys: next });
+  },
+  toggleFavorite: (key) => {
+    if (get().favoriteKeys.has(key)) get().removeFavorite(key);
+    else get().addFavorite(key);
+  },
+}));

--- a/src/utils/presetFavorites.test.ts
+++ b/src/utils/presetFavorites.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import {
+  projectmFavoriteKey,
+  butterchurnFavoriteKey,
+  favoriteKeyForIndex,
+} from './presetFavorites';
+import type { PresetIndexEntry } from '../types/presets';
+
+const entry = (name: string, path: string): PresetIndexEntry => ({
+  name,
+  path,
+  category: 'Test',
+  shard: 'Test.ndjson.gz',
+});
+
+describe('presetFavorites key helper', () => {
+  it('projectM favorite key uses the path, engine-prefixed', () => {
+    expect(projectmFavoriteKey('pack/sub/cool.milk')).toBe('projectm:pack/sub/cool.milk');
+  });
+
+  it('butterchurn favorite key uses the engine-prefixed name', () => {
+    expect(butterchurnFavoriteKey('Flexi - mom')).toBe('butterchurn:Flexi - mom');
+  });
+
+  it('duplicate projectM names with different paths produce DIFFERENT keys', () => {
+    const a = entry('Cool', 'packA/cool.milk');
+    const b = entry('Cool', 'packB/cool.milk');
+    const ka = favoriteKeyForIndex('projectm', 0, [a], ['Cool']);
+    const kb = favoriteKeyForIndex('projectm', 0, [b], ['Cool']);
+    expect(ka).not.toBe(kb);
+    expect(ka).toBe('projectm:packA/cool.milk');
+    expect(kb).toBe('projectm:packB/cool.milk');
+  });
+
+  it('resolves by path for projectM and by name for butterchurn', () => {
+    const entries = [entry('One', 'p/one.milk'), entry('Two', 'p/two.milk')];
+    expect(favoriteKeyForIndex('projectm', 1, entries, ['One', 'Two'])).toBe('projectm:p/two.milk');
+    expect(favoriteKeyForIndex('butterchurn', 1, [], ['One', 'Two'])).toBe('butterchurn:Two');
+  });
+
+  it('returns null for an out-of-range index or no engine', () => {
+    expect(favoriteKeyForIndex('projectm', 5, [], [])).toBeNull();
+    expect(favoriteKeyForIndex('butterchurn', 5, [], [])).toBeNull();
+    expect(favoriteKeyForIndex(null, 0, [], ['x'])).toBeNull();
+  });
+});

--- a/src/utils/presetFavorites.ts
+++ b/src/utils/presetFavorites.ts
@@ -1,0 +1,43 @@
+// Stable, engine-prefixed identity for a "favorited" visualizer preset.
+//
+// projectM preset *names* are NOT unique (the corpus has many duplicates), so
+// projectM favorites are keyed on the manifest `path` (the documented stable
+// unique key). butterchurn has no path — its preset names are the only stable
+// identity, so butterchurn favorites are keyed on `name`. The engine prefix
+// keeps the two corpora from colliding.
+import type { PresetIndexEntry } from '../types/presets';
+
+export type MilkdropEngine = 'projectm' | 'butterchurn';
+
+/** projectM favorite key from a manifest path. */
+export function projectmFavoriteKey(path: string): string {
+  return `projectm:${path}`;
+}
+
+/** butterchurn favorite key from a preset name. */
+export function butterchurnFavoriteKey(name: string): string {
+  return `butterchurn:${name}`;
+}
+
+/**
+ * Resolve the favorite key for an active-list index, per engine.
+ * - projectM: by `projectmEntries[index].path`
+ * - butterchurn: by `names[index]`
+ * Returns `null` if the index can't be resolved (e.g. list not ready).
+ */
+export function favoriteKeyForIndex(
+  engine: MilkdropEngine | null,
+  index: number,
+  projectmEntries: PresetIndexEntry[],
+  names: string[],
+): string | null {
+  if (engine === 'projectm') {
+    const entry = projectmEntries[index];
+    return entry ? projectmFavoriteKey(entry.path) : null;
+  }
+  if (engine === 'butterchurn') {
+    const name = names[index];
+    return name != null ? butterchurnFavoriteKey(name) : null;
+  }
+  return null;
+}


### PR DESCRIPTION
Promote `develop` → `master` for **v1.9.0-beta.9**. Ships the local-only visualizer preset favorites. Production remains **v1.9.0-beta.8** until this PR is merged.

## Included
**1. Visualizer preset favorites (PR #62)**
- Current-preset **☆/★ toggle** in the visualizer control bar.
- **Per-row favorite stars** in preset search.
- **Favorites filter** inside preset search.
- Versioned **localStorage** persistence: `vibrdrome_visualizer_favorites` = `{ "v": 1, "keys": [...] }`; malformed data degrades safely to empty; orphaned favorites kept but hidden if unresolvable.

**2. Favorite identity**
- projectM → `projectm:${path}` (stable manifest path); butterchurn → `butterchurn:${name}`.

**3. Release metadata (PR #63)**
- Version bumped to `1.9.0-beta.9`; About string updated; CHANGELOG entry added.

## Behavior preserved
Selecting a favorite still uses the existing preset-switch path → hard-cut · live fade/crossfade · reduced-motion · butterchurn · next/previous/random · auto-advance · `/` search · `?preset=` — all unchanged.

## Excluded
No HUD ★ indicator, no favoriting keyboard shortcut, no favorites-only random/auto-advance, no orphan cleanup, no sync. No rendering/engine/preset-bundle/dependency/workflow/Dockerfile/projectM-rs changes.

## Validation
- PR #62: 205 tests; projectM/WebGPU + forced-butterchurn manual checks; reload-persistence check; malformed-storage tests; 0 console errors.
- PR #63: metadata-only; CI green.
- This PR's CI runs fresh below.

## Queued commits (`master..develop`)
- PR #63 — `v1.9.0-beta.9` metadata
- PR #62 — visualizer preset favorites

> On merge, the **Deploy** workflow publishes to production (Cloudflare Pages + Docker Hub on `wrangler-action@v4`). The GitHub prerelease for `v1.9.0-beta.9` is created by the **Release** workflow when the `v1.9.0-beta.9` tag is pushed (a manual step after merge).