### PR TITLE
Prepare v1.9.0-beta.10 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.10] - 2026-06-21
+
+### Added
+- **★ Only visualizer playback mode** — restrict hands-off playback to your favorited presets.
+- **Favorites-only random / double-click** preset selection.
+- **Favorites-only auto-advance.**
+
+### Notes
+- With shuffle enabled, auto-advance picks **random favorites**; with shuffle disabled, it advances through favorites in **active-list order**.
+- **Zero favorites falls back to global behavior**, so playback never strands or goes black.
+- **One favorite** safely parks on that favorite.
+- **next / previous remain global and unchanged.**
+- The setting persists locally via `vibrdrome_visualizer_favorites_only`.
+- No rendering, engine, crossfade, preset-bundle, dependency, workflow, or Dockerfile changes.
+- Deferred (not in this release): next/previous favorites-only cycling, HUD ★ indicator, favoriting keyboard shortcut, orphaned-favorite cleanup, and cross-device sync.
+
 ## [1.9.0-beta.9] - 2026-06-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.9",
+  "version": "1.9.0-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.9",
+      "version": "1.9.0-beta.10",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.9",
+  "version": "1.9.0-beta.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.9</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.10</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">


### PR DESCRIPTION
Release-metadata prep for **v1.9.0-beta.10**. Metadata only — no code/behavior changes.

## Version bump
`1.9.0-beta.9` → `1.9.0-beta.10` in `package.json`, `package-lock.json` (root + `packages[""]` only — no dependency changes), and `src/screens/SettingsScreen.tsx` (About → `Vibrdrome Web v1.9.0-beta.10`).

## CHANGELOG — new `## [1.9.0-beta.10] - 2026-06-21`
- **Added:** ★ Only visualizer playback mode — favorites-only random/double-click and auto-advance.
- **Notes:** shuffle on → random favorites; shuffle off → next favorite in active-list order; zero favorites falls back to global (never strands); one favorite parks safely; next/previous remain global and unchanged; persists via `vibrdrome_visualizer_favorites_only`; no rendering/engine/crossfade/preset-bundle/dependency/workflow/Dockerfile changes.
- **Deferred:** next/previous favorites-only cycling, HUD ★ indicator, favoriting shortcut, orphan cleanup, sync.

## Scope / guardrails
- beta.10 payload is exactly **PR #65** (already on `develop`); this PR adds only version metadata + CHANGELOG.
- No dependency, Dockerfile, workflow, engine, or projectM changes. No `master`, tag, GitHub Release, or deploy — targets `develop` only.

## Validation
`npm run lint` ✅ · `npm run test:run` ✅ 217/217 · `npm run build` ✅ · `npm run test:smoke` ✅ (0 console errors).