### PR TITLE
Release v1.9.0-beta.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.10] - 2026-06-21
+
+### Added
+- **★ Only visualizer playback mode** — restrict hands-off playback to your favorited presets.
+- **Favorites-only random / double-click** preset selection.
+- **Favorites-only auto-advance.**
+
+### Notes
+- With shuffle enabled, auto-advance picks **random favorites**; with shuffle disabled, it advances through favorites in **active-list order**.
+- **Zero favorites falls back to global behavior**, so playback never strands or goes black.
+- **One favorite** safely parks on that favorite.
+- **next / previous remain global and unchanged.**
+- The setting persists locally via `vibrdrome_visualizer_favorites_only`.
+- No rendering, engine, crossfade, preset-bundle, dependency, workflow, or Dockerfile changes.
+- Deferred (not in this release): next/previous favorites-only cycling, HUD ★ indicator, favoriting keyboard shortcut, orphaned-favorite cleanup, and cross-device sync.
+
 ## [1.9.0-beta.9] - 2026-06-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.9",
+  "version": "1.9.0-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.9",
+      "version": "1.9.0-beta.10",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.9",
+  "version": "1.9.0-beta.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.9</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.10</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -11,7 +11,12 @@ import PresetSearch from '../components/visualizer/PresetSearch';
 import { useMediaQuery } from '../hooks/useMediaQuery';
 import { shouldCrossfade, captureSnapshot } from '../utils/presetCrossfade';
 import { usePresetFavoritesStore } from '../stores/presetFavoritesStore';
-import { favoriteKeyForIndex as resolveFavoriteKey } from '../utils/presetFavorites';
+import {
+  favoriteKeyForIndex as resolveFavoriteKey,
+  favoritedIndicesIn,
+  randomFavoriteIndex,
+  nextFavoriteIndex,
+} from '../utils/presetFavorites';
 import type { PresetIndexEntry } from '../types/presets';
 
 // projectM preset category that is excluded from normal selection: these are
@@ -228,6 +233,7 @@ export default function VisualizerScreen() {
     visualizerAutoAdvance, setVisualizerAutoAdvance,
     visualizerAutoAdvanceInterval, setVisualizerAutoAdvanceInterval,
     visualizerShuffle, setVisualizerShuffle,
+    visualizerFavoritesOnly, setVisualizerFavoritesOnly,
     visualizerShowTransport,
     visualizerTransitionPolish,
     visualizerParticles,
@@ -885,6 +891,19 @@ export default function VisualizerScreen() {
   const currentFavoriteKey = favoriteKeyForIndex(milkdropPresetIndex);
   const currentIsFavorite = currentFavoriteKey != null && favoriteKeys.has(currentFavoriteKey);
 
+  // Active-engine favorited indices, for favorites-only random / auto-advance.
+  const favoritedIndices = useMemo(
+    () => favoritedIndicesIn(milkdropPresetNames, favoriteKeys, favoriteKeyForIndex),
+    [milkdropPresetNames, favoriteKeys, favoriteKeyForIndex],
+  );
+  const hasActiveFavorites = favoritedIndices.length > 0;
+  // Refs so the interval-captured auto-advance always reads current values
+  // (favorites can change while it runs without re-subscribing the interval).
+  const favoritesOnlyRef = useRef(visualizerFavoritesOnly);
+  const favoritedIndicesRef = useRef<number[]>(favoritedIndices);
+  useEffect(() => { favoritesOnlyRef.current = visualizerFavoritesOnly; }, [visualizerFavoritesOnly]);
+  useEffect(() => { favoritedIndicesRef.current = favoritedIndices; }, [favoritedIndices]);
+
   const nextPreset = () => {
     setActiveIndex((i) => (i + 1) % totalPresets);
     resetOverlayTimer();
@@ -897,6 +916,15 @@ export default function VisualizerScreen() {
 
   const randomPreset = () => {
     if (totalPresets <= 1) return;
+    // Favorites-only: pick a favorited preset; fall back to global if none.
+    if (visualizerFavoritesOnly) {
+      const fav = randomFavoriteIndex(favoritedIndices, activeIndex);
+      if (fav != null) {
+        setActiveIndex(fav);
+        resetOverlayTimer();
+        return;
+      }
+    }
     let next: number;
     do {
       next = Math.floor(Math.random() * totalPresets);
@@ -910,18 +938,24 @@ export default function VisualizerScreen() {
   // Uses the functional updater so it never reads a stale index from the interval.
   const autoAdvance = () => {
     suppressNextToastRef.current = true;
-    if (visualizerShuffle) {
-      setActiveIndex((i) => {
-        if (totalPresets <= 1) return i;
+    setActiveIndex((i) => {
+      if (totalPresets <= 1) return i;
+      // Favorites-only: advance within favorites (random when shuffle, else the
+      // next favorite in list order). Falls back to global if no favorites.
+      if (favoritesOnlyRef.current) {
+        const favIdx = favoritedIndicesRef.current;
+        const pick = visualizerShuffle ? randomFavoriteIndex(favIdx, i) : nextFavoriteIndex(favIdx, i);
+        if (pick != null) return pick;
+      }
+      if (visualizerShuffle) {
         let next: number;
         do {
           next = Math.floor(Math.random() * totalPresets);
         } while (next === i);
         return next;
-      });
-    } else {
-      setActiveIndex((i) => (i + 1) % totalPresets);
-    }
+      }
+      return (i + 1) % totalPresets;
+    });
   };
 
   // Auto-advance: cycle presets on the configured interval while in Milkdrop.
@@ -1210,6 +1244,15 @@ export default function VisualizerScreen() {
             </button>
             <button onClick={(e) => { e.stopPropagation(); setVisualizerShuffle(!visualizerShuffle); resetOverlayTimer(); }} title="Shuffle on advance" className={ctrlBtn(visualizerShuffle)}>
               🔀 Shuffle
+            </button>
+            <button
+              onClick={(e) => { e.stopPropagation(); setVisualizerFavoritesOnly(!visualizerFavoritesOnly); resetOverlayTimer(); }}
+              disabled={!hasActiveFavorites}
+              title={hasActiveFavorites ? 'Random / auto-advance only among favorites' : 'Favorite some presets first'}
+              aria-pressed={visualizerFavoritesOnly}
+              className={ctrlBtn(visualizerFavoritesOnly, !hasActiveFavorites)}
+            >
+              ★ Only
             </button>
             <button onClick={(e) => { e.stopPropagation(); toggleFps(); }} title="FPS overlay (F)" className={ctrlBtn(showFps)}>
               FPS

--- a/src/stores/uiStore.test.ts
+++ b/src/stores/uiStore.test.ts
@@ -120,4 +120,17 @@ describe('uiStore', () => {
       expect(useUIStore.getState().epilepsyWarningDismissed).toBe(true);
     });
   });
+
+  describe('visualizerFavoritesOnly', () => {
+    it('defaults to off', () => {
+      expect(useUIStore.getState().visualizerFavoritesOnly).toBe(false);
+    });
+
+    it('toggles', () => {
+      useUIStore.getState().setVisualizerFavoritesOnly(true);
+      expect(useUIStore.getState().visualizerFavoritesOnly).toBe(true);
+      useUIStore.getState().setVisualizerFavoritesOnly(false);
+      expect(useUIStore.getState().visualizerFavoritesOnly).toBe(false);
+    });
+  });
 });

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -15,6 +15,7 @@ const VIS_FORCE_BUTTERCHURN_KEY = 'vibrdrome_visualizer_force_butterchurn';
 const VIS_AUTO_ADVANCE_KEY = 'vibrdrome_visualizer_auto_advance';
 const VIS_AUTO_ADVANCE_INTERVAL_KEY = 'vibrdrome_visualizer_auto_advance_interval';
 const VIS_SHUFFLE_KEY = 'vibrdrome_visualizer_shuffle';
+const VIS_FAVORITES_ONLY_KEY = 'vibrdrome_visualizer_favorites_only';
 const VIS_SHOW_TRANSPORT_KEY = 'vibrdrome_visualizer_show_transport';
 const VIS_TRANSITION_POLISH_KEY = 'vibrdrome_visualizer_transition_polish';
 const VIS_PARTICLES_KEY = 'vibrdrome_visualizer_particles';
@@ -70,6 +71,8 @@ interface UIState {
   setVisualizerAutoAdvanceInterval: (seconds: number) => void;
   visualizerShuffle: boolean;
   setVisualizerShuffle: (value: boolean) => void;
+  visualizerFavoritesOnly: boolean;
+  setVisualizerFavoritesOnly: (value: boolean) => void;
   visualizerShowTransport: boolean;
   setVisualizerShowTransport: (value: boolean) => void;
   visualizerTransitionPolish: boolean;
@@ -235,6 +238,11 @@ export const useUIStore = create<UIState>((set) => ({
   setVisualizerShuffle: (value) => {
     try { localStorage.setItem(VIS_SHUFFLE_KEY, String(value)); } catch { /* ignore */ }
     set({ visualizerShuffle: value });
+  },
+  visualizerFavoritesOnly: loadBool(VIS_FAVORITES_ONLY_KEY, false),
+  setVisualizerFavoritesOnly: (value) => {
+    try { localStorage.setItem(VIS_FAVORITES_ONLY_KEY, String(value)); } catch { /* ignore */ }
+    set({ visualizerFavoritesOnly: value });
   },
   // Conservative default: off. The transport self-hides with no song, so this
   // keeps existing behavior (and the smoke test) unchanged until opted in.

--- a/src/utils/presetFavorites.test.ts
+++ b/src/utils/presetFavorites.test.ts
@@ -3,6 +3,9 @@ import {
   projectmFavoriteKey,
   butterchurnFavoriteKey,
   favoriteKeyForIndex,
+  favoritedIndicesIn,
+  randomFavoriteIndex,
+  nextFavoriteIndex,
 } from './presetFavorites';
 import type { PresetIndexEntry } from '../types/presets';
 
@@ -42,5 +45,64 @@ describe('presetFavorites key helper', () => {
     expect(favoriteKeyForIndex('projectm', 5, [], [])).toBeNull();
     expect(favoriteKeyForIndex('butterchurn', 5, [], [])).toBeNull();
     expect(favoriteKeyForIndex(null, 0, [], ['x'])).toBeNull();
+  });
+});
+
+describe('favoritedIndicesIn', () => {
+  const names = ['A', 'B', 'C', 'D'];
+
+  it('resolves only the active-engine favorited indices (projectM, by path key)', () => {
+    const entries = names.map((n, i) => entry(n, `p/${i}.milk`));
+    const keyForIndex = (i: number) => favoriteKeyForIndex('projectm', i, entries, names);
+    const favs = new Set(['projectm:p/1.milk', 'projectm:p/3.milk']);
+    expect(favoritedIndicesIn(names, favs, keyForIndex)).toEqual([1, 3]);
+  });
+
+  it('resolves butterchurn favorites by name key', () => {
+    const keyForIndex = (i: number) => favoriteKeyForIndex('butterchurn', i, [], names);
+    const favs = new Set(['butterchurn:C']);
+    expect(favoritedIndicesIn(names, favs, keyForIndex)).toEqual([2]);
+  });
+
+  it('skips unresolvable keys and non-favorites', () => {
+    const keyForIndex = (i: number) => (i === 0 ? null : `k:${i}`);
+    expect(favoritedIndicesIn(names, new Set(['k:2']), keyForIndex)).toEqual([2]);
+  });
+});
+
+describe('randomFavoriteIndex', () => {
+  it('returns null for an empty list', () => {
+    expect(randomFavoriteIndex([], 0)).toBeNull();
+  });
+  it('returns the only favorite (even if it is the current one)', () => {
+    expect(randomFavoriteIndex([5], 5)).toBe(5);
+    expect(randomFavoriteIndex([5], 0)).toBe(5);
+  });
+  it('avoids the current index when multiple favorites exist', () => {
+    // rng=0 → first of the current-excluded pool; current=2 excluded → [1,3,4][0]=1
+    expect(randomFavoriteIndex([1, 2, 3, 4], 2, () => 0)).toBe(1);
+    // rng→last of the excluded pool
+    expect(randomFavoriteIndex([1, 2, 3, 4], 2, () => 0.999)).toBe(4);
+  });
+  it('is deterministic with an injected rng and never returns current', () => {
+    for (let r = 0; r < 1; r += 0.1) {
+      expect(randomFavoriteIndex([0, 1, 2], 1, () => r)).not.toBe(1);
+    }
+  });
+});
+
+describe('nextFavoriteIndex', () => {
+  it('returns null for an empty list', () => {
+    expect(nextFavoriteIndex([], 0)).toBeNull();
+  });
+  it('returns the only favorite', () => {
+    expect(nextFavoriteIndex([7], 3)).toBe(7);
+  });
+  it('returns the next favorite after current, wrapping', () => {
+    expect(nextFavoriteIndex([2, 5, 9], 2)).toBe(5);
+    expect(nextFavoriteIndex([2, 5, 9], 5)).toBe(9);
+    expect(nextFavoriteIndex([2, 5, 9], 9)).toBe(2); // wraps
+    expect(nextFavoriteIndex([2, 5, 9], 6)).toBe(9); // current not itself a favorite
+    expect(nextFavoriteIndex([2, 5, 9], 12)).toBe(2); // past the end → wrap
   });
 });

--- a/src/utils/presetFavorites.ts
+++ b/src/utils/presetFavorites.ts
@@ -41,3 +41,57 @@ export function favoriteKeyForIndex(
   }
   return null;
 }
+
+/**
+ * Active-engine list indices whose favorite key is currently favorited, in
+ * list order. `keyForIndex` resolves a row's key (null/unresolvable → skipped).
+ */
+export function favoritedIndicesIn(
+  names: string[],
+  favoriteKeys: Set<string>,
+  keyForIndex: (index: number) => string | null,
+): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < names.length; i++) {
+    const key = keyForIndex(i);
+    if (key != null && favoriteKeys.has(key)) out.push(i);
+  }
+  return out;
+}
+
+/**
+ * Pick a favorited index at random, avoiding `currentIndex` when possible.
+ * - empty list → `null`
+ * - single favorite → that index (even if it is the current one)
+ * - multiple → a random favorite, never `currentIndex`
+ * Uses a bounded selection (no unbounded retry loop). `rng` defaults to
+ * `Math.random` and is injectable for deterministic tests.
+ */
+export function randomFavoriteIndex(
+  favIndices: number[],
+  currentIndex: number,
+  rng: () => number = Math.random,
+): number | null {
+  if (favIndices.length === 0) return null;
+  if (favIndices.length === 1) return favIndices[0];
+  // Choose from the favorites excluding the current one, so we never retry.
+  const candidates = favIndices.filter((i) => i !== currentIndex);
+  const pool = candidates.length > 0 ? candidates : favIndices;
+  return pool[Math.floor(rng() * pool.length)];
+}
+
+/**
+ * The next favorited index after `currentIndex` in active-list order, wrapping.
+ * - empty list → `null`
+ * - single favorite → that index
+ * - otherwise → the first favorite with index > current, else the first favorite
+ *   (so it advances even when `currentIndex` isn't itself a favorite).
+ */
+export function nextFavoriteIndex(favIndices: number[], currentIndex: number): number | null {
+  if (favIndices.length === 0) return null;
+  if (favIndices.length === 1) return favIndices[0];
+  for (const i of favIndices) {
+    if (i > currentIndex) return i;
+  }
+  return favIndices[0];
+}


### PR DESCRIPTION
Promote `develop` → `master` for **v1.9.0-beta.10**. Ships the ★ Only favorites-only visualizer playback mode. Production remains **v1.9.0-beta.9** until this PR is merged.

## Included
**1. ★ Only visualizer playback mode (PR #65)**
- Persisted local setting `vibrdrome_visualizer_favorites_only`.
- Favorites-only random/double-click and auto-advance.
- Shuffle on → random favorites; shuffle off → next favorite in active-list order.
- Zero favorites → falls back to global (never strands); one favorite → parks safely.
- **next/previous remain global and unchanged.**

**2. Release metadata (PR #66)**
- Version bumped to `1.9.0-beta.10`; About string updated; CHANGELOG entry added.

## Behavior preserved
Preset selection still uses the existing preset-switch path → hard-cut · live fade/crossfade · reduced-motion · projectM/WebGPU · butterchurn · next/previous (global) · `/` search · `?preset=` · existing favorite-star behavior — all unchanged.

## Excluded
No next/previous favorites-only cycling, no HUD ★ indicator, no favoriting keyboard shortcut, no orphan cleanup, no sync. No rendering/engine/preset-bundle/dependency/workflow/Dockerfile/projectM-rs changes.

## Validation
- PR #65: 217 tests; projectM/WebGPU + forced-butterchurn manual checks; zero-favorites fallback; one-favorite edge; persistence; stale-closure/interval handled via refs; next/previous unchanged; 0 console errors.
- PR #66: metadata-only; CI green.
- This PR's CI runs fresh below.

## Queued commits (`master..develop`)
- PR #66 — `v1.9.0-beta.10` metadata
- PR #65 — ★ Only favorites-only visualizer playback

> On merge, the **Deploy** workflow publishes to production (Cloudflare Pages + Docker Hub on `wrangler-action@v4`). The GitHub prerelease for `v1.9.0-beta.10` is created by the **Release** workflow when the `v1.9.0-beta.10` tag is pushed (a manual step after merge).