### PR TITLE
Add favorites-only next and previous navigation

### DIFF
--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -16,6 +16,7 @@ import {
   favoritedIndicesIn,
   randomFavoriteIndex,
   nextFavoriteIndex,
+  previousFavoriteIndex,
 } from '../utils/presetFavorites';
 import type { PresetIndexEntry } from '../types/presets';
 
@@ -905,11 +906,29 @@ export default function VisualizerScreen() {
   useEffect(() => { favoritedIndicesRef.current = favoritedIndices; }, [favoritedIndices]);
 
   const nextPreset = () => {
+    // ★ Only: cycle to the next favorite; fall back to global if none.
+    if (visualizerFavoritesOnly) {
+      const fav = nextFavoriteIndex(favoritedIndices, activeIndex);
+      if (fav != null) {
+        setActiveIndex(fav);
+        resetOverlayTimer();
+        return;
+      }
+    }
     setActiveIndex((i) => (i + 1) % totalPresets);
     resetOverlayTimer();
   };
 
   const prevPreset = () => {
+    // ★ Only: cycle to the previous favorite; fall back to global if none.
+    if (visualizerFavoritesOnly) {
+      const fav = previousFavoriteIndex(favoritedIndices, activeIndex);
+      if (fav != null) {
+        setActiveIndex(fav);
+        resetOverlayTimer();
+        return;
+      }
+    }
     setActiveIndex((i) => (i - 1 + totalPresets) % totalPresets);
     resetOverlayTimer();
   };

--- a/src/utils/presetFavorites.test.ts
+++ b/src/utils/presetFavorites.test.ts
@@ -6,6 +6,7 @@ import {
   favoritedIndicesIn,
   randomFavoriteIndex,
   nextFavoriteIndex,
+  previousFavoriteIndex,
 } from './presetFavorites';
 import type { PresetIndexEntry } from '../types/presets';
 
@@ -104,5 +105,42 @@ describe('nextFavoriteIndex', () => {
     expect(nextFavoriteIndex([2, 5, 9], 9)).toBe(2); // wraps
     expect(nextFavoriteIndex([2, 5, 9], 6)).toBe(9); // current not itself a favorite
     expect(nextFavoriteIndex([2, 5, 9], 12)).toBe(2); // past the end → wrap
+  });
+});
+
+describe('previousFavoriteIndex', () => {
+  it('returns null for an empty list', () => {
+    expect(previousFavoriteIndex([], 0)).toBeNull();
+  });
+  it('returns the only favorite', () => {
+    expect(previousFavoriteIndex([7], 3)).toBe(7);
+    expect(previousFavoriteIndex([7], 9)).toBe(7);
+  });
+  it('returns the previous favorite before current', () => {
+    expect(previousFavoriteIndex([2, 5, 9], 9)).toBe(5);
+    expect(previousFavoriteIndex([2, 5, 9], 5)).toBe(2);
+  });
+  it('wraps to the last favorite when current is before/at the first favorite', () => {
+    expect(previousFavoriteIndex([2, 5, 9], 2)).toBe(9); // current == first fav → wrap to last
+    expect(previousFavoriteIndex([2, 5, 9], 0)).toBe(9); // before all favs → wrap to last
+  });
+  it('handles current not being a favorite', () => {
+    expect(previousFavoriteIndex([2, 5, 9], 7)).toBe(5); // largest fav < 7
+    expect(previousFavoriteIndex([2, 5, 9], 12)).toBe(9); // past the end → last
+  });
+  it('does not mutate the input', () => {
+    const favs = [2, 5, 9];
+    const copy = [...favs];
+    previousFavoriteIndex(favs, 5);
+    expect(favs).toEqual(copy);
+  });
+});
+
+describe('favoritedIndicesIn ascending order', () => {
+  it('produces indices in ascending active-list order', () => {
+    const names = ['a', 'b', 'c', 'd', 'e'];
+    const keyForIndex = (i: number) => `k:${i}`;
+    const favs = new Set(['k:4', 'k:1', 'k:3']); // out-of-order set
+    expect(favoritedIndicesIn(names, favs, keyForIndex)).toEqual([1, 3, 4]); // ascending
   });
 });

--- a/src/utils/presetFavorites.ts
+++ b/src/utils/presetFavorites.ts
@@ -95,3 +95,21 @@ export function nextFavoriteIndex(favIndices: number[], currentIndex: number): n
   }
   return favIndices[0];
 }
+
+/**
+ * The previous favorited index before `currentIndex` in active-list order,
+ * wrapping. Mirror of {@link nextFavoriteIndex}.
+ * - empty list → `null`
+ * - single favorite → that index
+ * - otherwise → the largest favorite with index < current, else wrap to the last
+ *   favorite (so it moves even when `currentIndex` isn't itself a favorite).
+ * Assumes `favIndices` is in ascending order; does not mutate it.
+ */
+export function previousFavoriteIndex(favIndices: number[], currentIndex: number): number | null {
+  if (favIndices.length === 0) return null;
+  if (favIndices.length === 1) return favIndices[0];
+  for (let k = favIndices.length - 1; k >= 0; k--) {
+    if (favIndices[k] < currentIndex) return favIndices[k];
+  }
+  return favIndices[favIndices.length - 1];
+}


### PR DESCRIPTION
Makes **next/previous respect the existing ★ Only mode**, completing favorites-only navigation (random + auto-advance already do).

## What it does
- Uses the existing **`visualizerFavoritesOnly`** setting (no new setting, no new UI).
- Adds pure helper **`previousFavoriteIndex`** (mirror of `nextFavoriteIndex`).
- **★ Only ON + active favorites exist:** next cycles forward through favorites, previous cycles backward (active-list order, wrapping).
- **★ Only OFF:** next/previous remain **global** (unchanged).
- **Zero favorites:** next/previous **fall back to global** (no strand/black/throw).
- **One favorite:** next/previous **park** on it (no loop).
- **Search & `?preset=` remain global/explicit** (you can still reach any preset in ★ Only mode); **random/auto-advance unchanged**.

## Scope
`src/utils/presetFavorites.ts` (+`previousFavoriteIndex`) + tests; `src/screens/VisualizerScreen.tsx` (`nextPreset`/`prevPreset` branches — synchronous handlers, no refs). **No** UI, setting, uiStore, PresetSearch, rendering, crossfade, engine, preset-bundle, dependency, workflow, Dockerfile, or release-metadata changes; projectM-rs untouched.

## Validation
- `npm run lint` ✅ · `npm run test:run` ✅ **224/224** (+7) · `npm run build` ✅ · `npm run test:smoke` ✅ (0 console errors).
- **projectM/WebGPU (headed real Chrome):** 3 **non-consecutive** favorites → ★ Only on → `n`×6 cycle all 3 favorites **skipping non-favorites**, `p`×6 backward through favorites → ★ Only off → `n` global again → 0 console errors.
- **Forced butterchurn:** same with 3 non-consecutive butterchurn favorites → `n`/`p` cycle only butterchurn favorites → off = global → 0 console errors.
- **Zero-favorites:** ★ Only disabled; forced-on + zero → `n`/`p` fall back to global and move (no strand) → 0 errors.
- **One-favorite:** ★ Only on → `n`/`p` park on the single favorite → 0 errors.
- **Search stays global** (`Showing … of 10343` / `of 100`); **random still favorites-only** under ★ Only.

`develop`-only until you choose to ship it (a future beta).