### PR TITLE
Prepare v1.9.0-beta.11 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.11] - 2026-06-21
+
+### Added
+- **Favorites-only next / previous** visualizer navigation — completes ★ Only mode so manual navigation respects your favorites too.
+
+### Notes
+- When **★ Only** is enabled and active-engine favorites exist, next/previous cycle through favorites in active-list order (wrapping).
+- When **★ Only** is disabled, next/previous remain **global**.
+- **Zero favorites falls back to global behavior**, so playback never strands.
+- **One favorite** safely parks on that favorite.
+- **Search and `?preset=` remain global / explicit** — you can still reach any preset in ★ Only mode.
+- **Random and auto-advance behavior are unchanged** from beta.10.
+- No rendering, engine, crossfade, preset-bundle, dependency, workflow, or Dockerfile changes.
+- Deferred (not in this release): HUD ★ indicator, favoriting keyboard shortcut, orphaned-favorite cleanup, and cross-device sync.
+
 ## [1.9.0-beta.10] - 2026-06-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.10",
+  "version": "1.9.0-beta.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.10",
+      "version": "1.9.0-beta.11",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.10",
+  "version": "1.9.0-beta.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.10</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.11</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">


### PR DESCRIPTION
Release-metadata prep for **v1.9.0-beta.11**. Metadata only — no code/behavior changes.

## Version bump
`1.9.0-beta.10` → `1.9.0-beta.11` in `package.json`, `package-lock.json` (root + `packages[""]` only — no dependency changes), and `src/screens/SettingsScreen.tsx` (About → `Vibrdrome Web v1.9.0-beta.11`).

## CHANGELOG — new `## [1.9.0-beta.11] - 2026-06-21`
- **Added:** favorites-only **next/previous** visualizer navigation — completes ★ Only mode.
- **Notes:** ★ Only on + favorites → next/previous cycle through favorites in active-list order; ★ Only off → global; zero favorites → global fallback (never strands); one favorite → parks; search/`?preset=` stay global; random/auto-advance unchanged; no rendering/engine/crossfade/preset-bundle/dependency/workflow/Dockerfile changes.
- **Deferred:** HUD ★ indicator, favoriting shortcut, orphan cleanup, sync.

## Scope / guardrails
- beta.11 payload is exactly **PR #68** (already on `develop`); this PR adds only version metadata + CHANGELOG.
- No dependency, Dockerfile, workflow, engine, or projectM changes. No `master`, tag, GitHub Release, or deploy — targets `develop` only.

## Validation
`npm run lint` ✅ · `npm run test:run` ✅ 224/224 · `npm run build` ✅ · `npm run test:smoke` ✅ (0 console errors).