### PR TITLE
Release v1.9.0-beta.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.11] - 2026-06-21
+
+### Added
+- **Favorites-only next / previous** visualizer navigation — completes ★ Only mode so manual navigation respects your favorites too.
+
+### Notes
+- When **★ Only** is enabled and active-engine favorites exist, next/previous cycle through favorites in active-list order (wrapping).
+- When **★ Only** is disabled, next/previous remain **global**.
+- **Zero favorites falls back to global behavior**, so playback never strands.
+- **One favorite** safely parks on that favorite.
+- **Search and `?preset=` remain global / explicit** — you can still reach any preset in ★ Only mode.
+- **Random and auto-advance behavior are unchanged** from beta.10.
+- No rendering, engine, crossfade, preset-bundle, dependency, workflow, or Dockerfile changes.
+- Deferred (not in this release): HUD ★ indicator, favoriting keyboard shortcut, orphaned-favorite cleanup, and cross-device sync.
+
 ## [1.9.0-beta.10] - 2026-06-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.10",
+  "version": "1.9.0-beta.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.10",
+      "version": "1.9.0-beta.11",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.10",
+  "version": "1.9.0-beta.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.10</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.11</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -16,6 +16,7 @@ import {
   favoritedIndicesIn,
   randomFavoriteIndex,
   nextFavoriteIndex,
+  previousFavoriteIndex,
 } from '../utils/presetFavorites';
 import type { PresetIndexEntry } from '../types/presets';
 
@@ -905,11 +906,29 @@ export default function VisualizerScreen() {
   useEffect(() => { favoritedIndicesRef.current = favoritedIndices; }, [favoritedIndices]);
 
   const nextPreset = () => {
+    // ★ Only: cycle to the next favorite; fall back to global if none.
+    if (visualizerFavoritesOnly) {
+      const fav = nextFavoriteIndex(favoritedIndices, activeIndex);
+      if (fav != null) {
+        setActiveIndex(fav);
+        resetOverlayTimer();
+        return;
+      }
+    }
     setActiveIndex((i) => (i + 1) % totalPresets);
     resetOverlayTimer();
   };
 
   const prevPreset = () => {
+    // ★ Only: cycle to the previous favorite; fall back to global if none.
+    if (visualizerFavoritesOnly) {
+      const fav = previousFavoriteIndex(favoritedIndices, activeIndex);
+      if (fav != null) {
+        setActiveIndex(fav);
+        resetOverlayTimer();
+        return;
+      }
+    }
     setActiveIndex((i) => (i - 1 + totalPresets) % totalPresets);
     resetOverlayTimer();
   };

--- a/src/utils/presetFavorites.test.ts
+++ b/src/utils/presetFavorites.test.ts
@@ -6,6 +6,7 @@ import {
   favoritedIndicesIn,
   randomFavoriteIndex,
   nextFavoriteIndex,
+  previousFavoriteIndex,
 } from './presetFavorites';
 import type { PresetIndexEntry } from '../types/presets';
 
@@ -104,5 +105,42 @@ describe('nextFavoriteIndex', () => {
     expect(nextFavoriteIndex([2, 5, 9], 9)).toBe(2); // wraps
     expect(nextFavoriteIndex([2, 5, 9], 6)).toBe(9); // current not itself a favorite
     expect(nextFavoriteIndex([2, 5, 9], 12)).toBe(2); // past the end → wrap
+  });
+});
+
+describe('previousFavoriteIndex', () => {
+  it('returns null for an empty list', () => {
+    expect(previousFavoriteIndex([], 0)).toBeNull();
+  });
+  it('returns the only favorite', () => {
+    expect(previousFavoriteIndex([7], 3)).toBe(7);
+    expect(previousFavoriteIndex([7], 9)).toBe(7);
+  });
+  it('returns the previous favorite before current', () => {
+    expect(previousFavoriteIndex([2, 5, 9], 9)).toBe(5);
+    expect(previousFavoriteIndex([2, 5, 9], 5)).toBe(2);
+  });
+  it('wraps to the last favorite when current is before/at the first favorite', () => {
+    expect(previousFavoriteIndex([2, 5, 9], 2)).toBe(9); // current == first fav → wrap to last
+    expect(previousFavoriteIndex([2, 5, 9], 0)).toBe(9); // before all favs → wrap to last
+  });
+  it('handles current not being a favorite', () => {
+    expect(previousFavoriteIndex([2, 5, 9], 7)).toBe(5); // largest fav < 7
+    expect(previousFavoriteIndex([2, 5, 9], 12)).toBe(9); // past the end → last
+  });
+  it('does not mutate the input', () => {
+    const favs = [2, 5, 9];
+    const copy = [...favs];
+    previousFavoriteIndex(favs, 5);
+    expect(favs).toEqual(copy);
+  });
+});
+
+describe('favoritedIndicesIn ascending order', () => {
+  it('produces indices in ascending active-list order', () => {
+    const names = ['a', 'b', 'c', 'd', 'e'];
+    const keyForIndex = (i: number) => `k:${i}`;
+    const favs = new Set(['k:4', 'k:1', 'k:3']); // out-of-order set
+    expect(favoritedIndicesIn(names, favs, keyForIndex)).toEqual([1, 3, 4]); // ascending
   });
 });

--- a/src/utils/presetFavorites.ts
+++ b/src/utils/presetFavorites.ts
@@ -95,3 +95,21 @@ export function nextFavoriteIndex(favIndices: number[], currentIndex: number): n
   }
   return favIndices[0];
 }
+
+/**
+ * The previous favorited index before `currentIndex` in active-list order,
+ * wrapping. Mirror of {@link nextFavoriteIndex}.
+ * - empty list → `null`
+ * - single favorite → that index
+ * - otherwise → the largest favorite with index < current, else wrap to the last
+ *   favorite (so it moves even when `currentIndex` isn't itself a favorite).
+ * Assumes `favIndices` is in ascending order; does not mutate it.
+ */
+export function previousFavoriteIndex(favIndices: number[], currentIndex: number): number | null {
+  if (favIndices.length === 0) return null;
+  if (favIndices.length === 1) return favIndices[0];
+  for (let k = favIndices.length - 1; k >= 0; k--) {
+    if (favIndices[k] < currentIndex) return favIndices[k];
+  }
+  return favIndices[favIndices.length - 1];
+}


### PR DESCRIPTION
Promote `develop` → `master` for **v1.9.0-beta.11**. Ships favorites-only next/previous navigation. Production remains **v1.9.0-beta.10** until this PR is merged.

## Included
**1. Favorites-only next/previous navigation (PR #68)** — completes ★ Only mode.
- ★ Only on + active favorites → next cycles forward through favorites, previous cycles backward (active-list order, wrapping).
- ★ Only off → next/previous remain **global**.
- Zero favorites → falls back to global (never strands); one favorite → parks safely.
- **Search and `?preset=` remain global/explicit**; **random and auto-advance unchanged from beta.10**.

**2. Release metadata (PR #69)**
- Version bumped to `1.9.0-beta.11`; About string updated; CHANGELOG entry added.

## Behavior preserved
Preset selection still uses the existing preset-switch path → hard-cut · live fade/crossfade · reduced-motion · projectM/WebGPU · butterchurn · `/` search · `?preset=` · existing favorite-star behavior · ★ Only random/auto-advance (beta.10) — all unchanged.

## Excluded
No HUD ★ indicator, no favoriting keyboard shortcut, no orphan cleanup, no sync. No rendering/engine/preset-bundle/dependency/workflow/Dockerfile/projectM-rs changes.

## Validation
- PR #68: 224 tests; projectM/WebGPU + forced-butterchurn manual checks with **non-consecutive favorites**; zero-favorites fallback; one-favorite park; search/`?preset=` confirmed global; random/auto-advance unchanged; 0 console errors.
- PR #69: metadata-only; CI green.
- This PR's CI runs fresh below.

## Queued commits (`master..develop`)
- PR #69 — `v1.9.0-beta.11` metadata
- PR #68 — favorites-only next/previous navigation

> On merge, the **Deploy** workflow publishes to production (Cloudflare Pages + Docker Hub on `wrangler-action@v4`). The GitHub prerelease for `v1.9.0-beta.11` is created by the **Release** workflow when the `v1.9.0-beta.11` tag is pushed (a manual step after merge).