### PR TITLE
Release v1.9.0-beta.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.12] - 2026-06-21
+
+### Added
+- **Display-only HUD ★ indicator** for favorited visualizer presets.
+
+### Notes
+- The ★ appears beside the HUD preset name when the current preset is favorited.
+- The indicator is **display-only and not clickable**.
+- The existing control-bar **☆/★ button remains the only favorite toggle**.
+- **No outline ☆** is shown for non-favorites.
+- **Shader / non-Milkdrop mode does not show the indicator.**
+- **Favorite identity/storage is unchanged.**
+- **Search, ★ Only, next/previous, random, auto-advance, and `?preset=` are unchanged.**
+- No rendering, engine, crossfade, preset-bundle, dependency, workflow, or Dockerfile changes.
+- Deferred (not in this release): favoriting keyboard shortcut, orphaned-favorite cleanup, and cross-device sync.
+
 ## [1.9.0-beta.11] - 2026-06-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.11",
+  "version": "1.9.0-beta.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.11",
+      "version": "1.9.0-beta.12",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.11",
+  "version": "1.9.0-beta.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/visualizer/VisualizerHud.test.tsx
+++ b/src/components/visualizer/VisualizerHud.test.tsx
@@ -44,6 +44,88 @@ describe('VisualizerHud', () => {
     expect(screen.queryByText('Shuffle')).not.toBeInTheDocument();
   });
 
+  it('shows the ★ favorite indicator when isFavorite and a Milkdrop preset is shown', () => {
+    render(
+      <VisualizerHud
+        presetName="Geiss - Cosmic"
+        engine="projectm"
+        index={3}
+        total={120}
+        autoAdvance={false}
+        shuffle={false}
+        frozen={false}
+        isFavorite
+      />,
+    );
+    const star = screen.getByLabelText('Favorited');
+    expect(star).toBeInTheDocument();
+    expect(star).toHaveTextContent('★');
+    // Name still renders alongside the star.
+    expect(screen.getByText('Geiss - Cosmic')).toBeInTheDocument();
+  });
+
+  it('does not show the ★ when isFavorite is false or omitted', () => {
+    const { rerender } = render(
+      <VisualizerHud
+        presetName="Geiss - Cosmic"
+        engine="projectm"
+        index={3}
+        total={120}
+        autoAdvance={false}
+        shuffle={false}
+        frozen={false}
+        isFavorite={false}
+      />,
+    );
+    expect(screen.queryByLabelText('Favorited')).not.toBeInTheDocument();
+    // Omitted prop → defaults to not favorited.
+    rerender(
+      <VisualizerHud
+        presetName="Geiss - Cosmic"
+        engine="projectm"
+        index={3}
+        total={120}
+        autoAdvance={false}
+        shuffle={false}
+        frozen={false}
+      />,
+    );
+    expect(screen.queryByLabelText('Favorited')).not.toBeInTheDocument();
+  });
+
+  it('does not show the ★ in shader mode even when isFavorite is true', () => {
+    render(
+      <VisualizerHud
+        presetName="Plasma"
+        engine={null}
+        index={1}
+        total={6}
+        autoAdvance={false}
+        shuffle={false}
+        frozen={false}
+        isFavorite
+      />,
+    );
+    expect(screen.queryByLabelText('Favorited')).not.toBeInTheDocument();
+    expect(screen.getByText('Plasma')).toBeInTheDocument();
+  });
+
+  it('shows the ★ for a favorited butterchurn preset', () => {
+    render(
+      <VisualizerHud
+        presetName="Fallback"
+        engine="butterchurn"
+        index={1}
+        total={50}
+        autoAdvance={false}
+        shuffle={false}
+        frozen={false}
+        isFavorite
+      />,
+    );
+    expect(screen.getByLabelText('Favorited')).toBeInTheDocument();
+  });
+
   it('labels the butterchurn engine badge', () => {
     render(
       <VisualizerHud

--- a/src/components/visualizer/VisualizerHud.tsx
+++ b/src/components/visualizer/VisualizerHud.tsx
@@ -7,6 +7,8 @@ interface VisualizerHudProps {
   autoAdvance: boolean;
   shuffle: boolean;
   frozen: boolean;
+  /** Whether the current preset is favorited — shows a leading ★ in Milkdrop mode. */
+  isFavorite?: boolean;
 }
 
 const badge = 'rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide';
@@ -16,10 +18,17 @@ const badge = 'rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase trac
  * status badges (engine, position, auto/shuffle/frozen). Pure/presentational —
  * the toast and transition polish live in VisualizerScreen.
  */
-export default function VisualizerHud({ presetName, engine, index, total, autoAdvance, shuffle, frozen }: VisualizerHudProps) {
+export default function VisualizerHud({ presetName, engine, index, total, autoAdvance, shuffle, frozen, isFavorite = false }: VisualizerHudProps) {
+  // The ★ is a passive indicator; favorites only apply in Milkdrop mode (engine set).
+  const showFavorite = isFavorite && engine != null;
   return (
     <div className="flex max-w-[60%] flex-col items-center gap-1">
-      <span className="truncate text-sm font-medium text-white/90">{presetName}</span>
+      <span className="flex min-w-0 items-center gap-1 text-sm font-medium text-white/90">
+        {showFavorite && (
+          <span role="img" aria-label="Favorited" className="shrink-0 text-amber-300">★</span>
+        )}
+        <span className="truncate">{presetName}</span>
+      </span>
       {engine && (
         <div className="flex flex-wrap items-center justify-center gap-1">
           <span className={`${badge} flex items-center gap-1 bg-white/10 text-white/70`}>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.11</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.12</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -1166,6 +1166,7 @@ export default function VisualizerScreen() {
             autoAdvance={visualizerAutoAdvance}
             shuffle={visualizerShuffle}
             frozen={frozen}
+            isFavorite={currentIsFavorite}
           />
 
           {/* Right controls: fullscreen toggle (when supported) + mode toggle */}


### PR DESCRIPTION
## Summary
- Promote **v1.9.0-beta.12** to production.
- Ships the **display-only HUD ★ favorite indicator**.
- Production remains **v1.9.0-beta.11** until this PR is merged.

## Included

### 1. HUD ★ favorite indicator (PR #71)
- Shows a filled ★ beside the HUD preset name when the current visualizer preset is favorited.
- **Display-only** — **not clickable**.
- **No outline ☆** for non-favorites.
- The existing control-bar **☆/★ button remains the only favorite toggle**.
- **Shader / non-Milkdrop mode does not show** the indicator.
- Preserves preset-name **truncation/layout**.

### 2. Release metadata (PR #72)
- Version bumped to **1.9.0-beta.12** (`package.json`, `package-lock.json`).
- About string updated to `Vibrdrome Web v1.9.0-beta.12`.
- CHANGELOG updated with the `[1.9.0-beta.12]` entry.

## Behavior preserved
favorite identity/storage · preset switching · preset search · ★ Only · next/previous · random · auto-advance · `?preset=` · rendering/crossfade/engine · projectM/WebGPU · butterchurn.

## Excluded
no favoriting shortcut · no orphan cleanup · no sync · no rendering changes · no engine changes · no preset-bundle changes · no dependency changes · no workflow/Dockerfile changes · no projectM-rs changes.

## Validation
- **PR #71:** 228 tests passing; projectM/WebGPU manual check (★ appears/disappears reactively); butterchurn component-test coverage; truncation/layout preserved; 0 console errors.
- **PR #72:** metadata-only; CI green; lockfile diff is only the two version fields.
- Promotion-PR checks run below and must pass before merge approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)