### PR TITLE
Add visualizer favorite keyboard shortcut

### DIFF
--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -1004,7 +1004,15 @@ export default function VisualizerScreen() {
         case ']': setVisualizerAutoAdvanceInterval(Math.min(60, visualizerAutoAdvanceInterval + 5)); resetOverlayTimer(); break;
         case 'k': case 'K': toggleFreeze(); break;
         case '.': stepFrame(); break;
-        case 'f': case 'F': toggleFps(); break;
+        case 'f': toggleFps(); break;
+        case 'F':
+          // Shift+F toggles favorite for the current preset (same path as the
+          // control-bar ☆/★ button). Ignore key-repeat to avoid flapping on hold.
+          if (!e.repeat && currentFavoriteKey) {
+            toggleFavorite(currentFavoriteKey);
+            resetOverlayTimer();
+          }
+          break;
         case '/':
           if (mode === 'milkdrop' && milkdropReady) {
             e.preventDefault();
@@ -1246,7 +1254,7 @@ export default function VisualizerScreen() {
             <button
               onClick={(e) => { e.stopPropagation(); if (currentFavoriteKey) toggleFavorite(currentFavoriteKey); resetOverlayTimer(); }}
               disabled={!currentFavoriteKey}
-              title={currentIsFavorite ? 'Unfavorite this preset' : 'Favorite this preset'}
+              title={currentIsFavorite ? 'Unfavorite this preset (⇧F)' : 'Favorite this preset (⇧F)'}
               aria-label={currentIsFavorite ? 'Unfavorite preset' : 'Favorite preset'}
               aria-pressed={currentIsFavorite}
               className={ctrlBtn(currentIsFavorite, !currentFavoriteKey)}
@@ -1274,7 +1282,7 @@ export default function VisualizerScreen() {
             >
               ★ Only
             </button>
-            <button onClick={(e) => { e.stopPropagation(); toggleFps(); }} title="FPS overlay (F)" className={ctrlBtn(showFps)}>
+            <button onClick={(e) => { e.stopPropagation(); toggleFps(); }} title="FPS overlay (f)" className={ctrlBtn(showFps)}>
               FPS
             </button>
             {visualizerShowTransport && (


### PR DESCRIPTION
## Summary
Adds a keyboard shortcut to favorite/unfavorite the current visualizer preset.

- Adds **`Shift+F`** to toggle favorite for the current visualizer preset.
- **Preserves lowercase `f`** for the FPS overlay (the combined `f`/`F` case is split).
- Uses the existing **`toggleFavorite(currentFavoriteKey)`** path — same as the control-bar ☆/★ button.
- Calls **`resetOverlayTimer()`** so the HUD ★ / control-bar feedback is visible.
- **Ignores repeated `Shift+F` keydown** (`!e.repeat`) to avoid rapid toggle flapping on key-hold.
- No-ops when `currentFavoriteKey` is null (shader / not-ready) — no error, no toast.
- The existing **input/search guard** (`INPUT`/`TEXTAREA`/`SELECT`) prevents the shortcut while typing.
- Favorite button `title` now advertises **`(⇧F)`**.
- FPS button tooltip corrected `(F)` → **`(f)`** to match the split (the only behavior is the tooltip text; FPS toggle itself unchanged).

## Out of scope / unchanged
- No favorite identity/storage changes.
- No search / ★ Only / next-previous / random / auto-advance / `?preset=` changes.
- No rendering/crossfade/engine changes.
- No dependency / workflow / Dockerfile / release-metadata changes.
- No `*` shortcut, toast, setting, persistence, or shortcuts legend.

## Test plan
- `npm run lint` — clean
- `npm run test:run` — 228/228
- `npm run build` — succeeds
- `npm run test:smoke` — 0 console errors
- Manual (real Chrome, projectM/WebGPU, epilepsy gate dismissed): `Shift+F` toggles favorite (HUD ★ + control-bar flip); lowercase `f` still toggles FPS (favorite untouched); typing `fF` in search toggles nothing; `N`/`P` navigate; 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)