### PR TITLE
Prepare v1.9.0-beta.13 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.13] - 2026-06-21
+
+### Added
+- **`Shift+F` keyboard shortcut** to favorite / unfavorite the current visualizer preset.
+
+### Notes
+- Lowercase `f` still toggles the FPS overlay.
+- The shortcut uses the existing favorite-toggle path.
+- Repeated `Shift+F` keydown events are ignored to avoid rapid toggle flapping.
+- Shortcut handling is suppressed while typing in inputs / search.
+- The control-bar favorite button now advertises `(⇧F)`.
+- **Favorite identity/storage is unchanged.**
+- **Search, ★ Only, next/previous, random, auto-advance, and `?preset=` are unchanged.**
+- No rendering, engine, crossfade, preset-bundle, dependency, workflow, or Dockerfile changes.
+- Deferred (not in this release): orphaned-favorite cleanup and cross-device sync.
+
 ## [1.9.0-beta.12] - 2026-06-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.12",
+  "version": "1.9.0-beta.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.12",
+      "version": "1.9.0-beta.13",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.12",
+  "version": "1.9.0-beta.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.12</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.13</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">


### PR DESCRIPTION
## Summary

Release metadata for **v1.9.0-beta.13**, shipping the `Shift+F` visualizer favorite shortcut already merged to `develop` (PR #74).

- **Version bump** `1.9.0-beta.12` → `1.9.0-beta.13` (`package.json`, `package-lock.json` root + `packages[""]`, `SettingsScreen` About string).
- **CHANGELOG** entry for the `Shift+F` visualizer favorite shortcut.
- **No dependency changes** (lockfile touches only the two version fields).
- **No workflow / Dockerfile changes.**
- **No engine / projectM / rendering / crossfade / preset-bundle changes.**
- **No release/deploy yet** — metadata only.

## Files changed (4)
- `package.json`
- `package-lock.json`
- `src/screens/SettingsScreen.tsx`
- `CHANGELOG.md`

## CHANGELOG [1.9.0-beta.13]
Added: `Shift+F` keyboard shortcut to favorite/unfavorite the current visualizer preset. Notes: lowercase `f` still toggles the FPS overlay; uses the existing favorite-toggle path; repeated `Shift+F` keydown ignored to avoid flapping; suppressed while typing in inputs/search; control-bar favorite button now advertises `(⇧F)`; favorite identity/storage unchanged; search, ★ Only, next/previous, random, auto-advance, and `?preset=` unchanged; no rendering/engine/crossfade/preset-bundle/dependency/workflow/Dockerfile changes. Deferred: orphaned-favorite cleanup and cross-device sync.

## Test plan
- `npm run lint` — clean
- `npm run test:run` — 228/228
- `npm run build` — succeeds
- `npm run test:smoke` — 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)