### PR TITLE
Release v1.9.0-beta.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.13] - 2026-06-21
+
+### Added
+- **`Shift+F` keyboard shortcut** to favorite / unfavorite the current visualizer preset.
+
+### Notes
+- Lowercase `f` still toggles the FPS overlay.
+- The shortcut uses the existing favorite-toggle path.
+- Repeated `Shift+F` keydown events are ignored to avoid rapid toggle flapping.
+- Shortcut handling is suppressed while typing in inputs / search.
+- The control-bar favorite button now advertises `(⇧F)`.
+- **Favorite identity/storage is unchanged.**
+- **Search, ★ Only, next/previous, random, auto-advance, and `?preset=` are unchanged.**
+- No rendering, engine, crossfade, preset-bundle, dependency, workflow, or Dockerfile changes.
+- Deferred (not in this release): orphaned-favorite cleanup and cross-device sync.
+
 ## [1.9.0-beta.12] - 2026-06-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.12",
+  "version": "1.9.0-beta.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.12",
+      "version": "1.9.0-beta.13",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.12",
+  "version": "1.9.0-beta.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.12</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.13</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -1004,7 +1004,15 @@ export default function VisualizerScreen() {
         case ']': setVisualizerAutoAdvanceInterval(Math.min(60, visualizerAutoAdvanceInterval + 5)); resetOverlayTimer(); break;
         case 'k': case 'K': toggleFreeze(); break;
         case '.': stepFrame(); break;
-        case 'f': case 'F': toggleFps(); break;
+        case 'f': toggleFps(); break;
+        case 'F':
+          // Shift+F toggles favorite for the current preset (same path as the
+          // control-bar ☆/★ button). Ignore key-repeat to avoid flapping on hold.
+          if (!e.repeat && currentFavoriteKey) {
+            toggleFavorite(currentFavoriteKey);
+            resetOverlayTimer();
+          }
+          break;
         case '/':
           if (mode === 'milkdrop' && milkdropReady) {
             e.preventDefault();
@@ -1246,7 +1254,7 @@ export default function VisualizerScreen() {
             <button
               onClick={(e) => { e.stopPropagation(); if (currentFavoriteKey) toggleFavorite(currentFavoriteKey); resetOverlayTimer(); }}
               disabled={!currentFavoriteKey}
-              title={currentIsFavorite ? 'Unfavorite this preset' : 'Favorite this preset'}
+              title={currentIsFavorite ? 'Unfavorite this preset (⇧F)' : 'Favorite this preset (⇧F)'}
               aria-label={currentIsFavorite ? 'Unfavorite preset' : 'Favorite preset'}
               aria-pressed={currentIsFavorite}
               className={ctrlBtn(currentIsFavorite, !currentFavoriteKey)}
@@ -1274,7 +1282,7 @@ export default function VisualizerScreen() {
             >
               ★ Only
             </button>
-            <button onClick={(e) => { e.stopPropagation(); toggleFps(); }} title="FPS overlay (F)" className={ctrlBtn(showFps)}>
+            <button onClick={(e) => { e.stopPropagation(); toggleFps(); }} title="FPS overlay (f)" className={ctrlBtn(showFps)}>
               FPS
             </button>
             {visualizerShowTransport && (


### PR DESCRIPTION
## Summary
- Promote **v1.9.0-beta.13** to production.
- Ships the **`Shift+F` visualizer favorite shortcut**.
- Production remains **v1.9.0-beta.12** until this PR is merged.

## Included

### 1. Shift+F favorite shortcut (PR #74)
- **`Shift+F`** favorites/unfavorites the current visualizer preset.
- Uses the existing **favorite-toggle path** (`toggleFavorite(currentFavoriteKey)`).
- Wakes the overlay via **`resetOverlayTimer()`** so HUD ★ / control-bar feedback is visible.
- **Ignores repeated `Shift+F` keydown** (`!e.repeat`) to avoid rapid toggle flapping.
- **Lowercase `f` still toggles the FPS overlay.**
- Shortcut is **suppressed while typing** in inputs / search.
- Favorite button title advertises **`(⇧F)`** (FPS button tooltip corrected to `(f)`).

### 2. Release metadata (PR #75)
- Version bumped to **1.9.0-beta.13** (`package.json`, `package-lock.json`).
- About string updated to `Vibrdrome Web v1.9.0-beta.13`.
- CHANGELOG updated with the `[1.9.0-beta.13]` entry.

## Behavior preserved
favorite identity/storage · preset switching · preset search · ★ Only · next/previous · random · auto-advance · `?preset=` · rendering/crossfade/engine · projectM/WebGPU · butterchurn.

## Excluded
no orphan cleanup · no sync · no shortcut legend · no toast · no rendering changes · no engine changes · no preset-bundle changes · no dependency changes · no workflow/Dockerfile changes · no projectM-rs changes.

## Validation
- **PR #74:** 228 tests passing; projectM/WebGPU manual check — `Shift+F` toggles favorite, lowercase `f` still toggles FPS, search/input typing guard confirmed, `n`/`p` navigation confirmed, 0 console errors.
- **PR #75:** metadata-only; CI green; lockfile diff is only the two version fields.
- Promotion-PR checks run below and must pass before merge approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)