### PR TITLE
Add orphaned favorite detection helper

### DIFF
--- a/src/utils/presetFavorites.test.ts
+++ b/src/utils/presetFavorites.test.ts
@@ -7,6 +7,7 @@ import {
   randomFavoriteIndex,
   nextFavoriteIndex,
   previousFavoriteIndex,
+  orphanedFavorites,
 } from './presetFavorites';
 import type { PresetIndexEntry } from '../types/presets';
 
@@ -142,5 +143,94 @@ describe('favoritedIndicesIn ascending order', () => {
     const keyForIndex = (i: number) => `k:${i}`;
     const favs = new Set(['k:4', 'k:1', 'k:3']); // out-of-order set
     expect(favoritedIndicesIn(names, favs, keyForIndex)).toEqual([1, 3, 4]); // ascending
+  });
+});
+
+describe('orphanedFavorites', () => {
+  const pmPaths = new Set(['packA/cool.milk', 'packB/warm.milk']);
+  const bcNames = new Set(['Flexi - mom', 'Geiss - Cosmic']);
+
+  it('does NOT flag a valid projectM key when the projectM corpus is loaded', () => {
+    expect(orphanedFavorites(['projectm:packA/cool.milk'], { projectmPaths: pmPaths })).toEqual([]);
+  });
+
+  it('detects an invalid projectM key when the projectM corpus is loaded', () => {
+    expect(orphanedFavorites(['projectm:packZ/gone.milk'], { projectmPaths: pmPaths })).toEqual([
+      'projectm:packZ/gone.milk',
+    ]);
+  });
+
+  it('does NOT evaluate projectM keys when projectmPaths is absent (corpus not loaded)', () => {
+    expect(orphanedFavorites(['projectm:packZ/gone.milk'], {})).toEqual([]);
+    expect(orphanedFavorites(['projectm:packZ/gone.milk'], { butterchurnNames: bcNames })).toEqual([]);
+  });
+
+  it('does NOT evaluate projectM keys when projectmPaths is empty (load race)', () => {
+    expect(orphanedFavorites(['projectm:packZ/gone.milk'], { projectmPaths: new Set() })).toEqual([]);
+  });
+
+  it('does NOT flag a valid butterchurn key when the butterchurn corpus is loaded', () => {
+    expect(orphanedFavorites(['butterchurn:Flexi - mom'], { butterchurnNames: bcNames })).toEqual([]);
+  });
+
+  it('detects an invalid butterchurn key when the butterchurn corpus is loaded', () => {
+    expect(orphanedFavorites(['butterchurn:Deleted - preset'], { butterchurnNames: bcNames })).toEqual([
+      'butterchurn:Deleted - preset',
+    ]);
+  });
+
+  it('does NOT evaluate butterchurn keys when butterchurnNames is absent (corpus not loaded)', () => {
+    expect(orphanedFavorites(['butterchurn:Deleted - preset'], {})).toEqual([]);
+    expect(orphanedFavorites(['butterchurn:Deleted - preset'], { projectmPaths: pmPaths })).toEqual([]);
+  });
+
+  it('does NOT evaluate butterchurn keys when butterchurnNames is empty (load race)', () => {
+    expect(orphanedFavorites(['butterchurn:Deleted - preset'], { butterchurnNames: new Set() })).toEqual([]);
+  });
+
+  it('with mixed favorites, only flags keys for engines whose corpus is loaded', () => {
+    // projectM corpus loaded, butterchurn corpus NOT loaded.
+    const favs = [
+      'projectm:packA/cool.milk', // valid pm → not flagged
+      'projectm:packZ/gone.milk', // invalid pm → flagged
+      'butterchurn:Flexi - mom', // bc corpus absent → not evaluable
+      'butterchurn:Deleted - preset', // bc corpus absent → not evaluable
+    ];
+    expect(orphanedFavorites(favs, { projectmPaths: pmPaths })).toEqual(['projectm:packZ/gone.milk']);
+  });
+
+  it('never flags inactive/absent-engine favorites even when they would be invalid', () => {
+    // A butterchurn-only session: projectM corpus absent. The (invalid-looking)
+    // projectM key must be left untouched — we cannot see its corpus.
+    expect(
+      orphanedFavorites(['projectm:packZ/gone.milk', 'butterchurn:Flexi - mom'], {
+        butterchurnNames: bcNames,
+      }),
+    ).toEqual([]);
+  });
+
+  it('does not mutate its inputs', () => {
+    const favs = ['projectm:packZ/gone.milk', 'butterchurn:Flexi - mom'];
+    const favsCopy = [...favs];
+    const pm = new Set(pmPaths);
+    const bc = new Set(bcNames);
+    orphanedFavorites(favs, { projectmPaths: pm, butterchurnNames: bc });
+    expect(favs).toEqual(favsCopy);
+    expect([...pm]).toEqual([...pmPaths]);
+    expect([...bc]).toEqual([...bcNames]);
+  });
+
+  it('never flags unknown-prefix keys', () => {
+    expect(
+      orphanedFavorites(['weird:thing', 'no-prefix', 'projectm:packZ/gone.milk'], {
+        projectmPaths: pmPaths,
+        butterchurnNames: bcNames,
+      }),
+    ).toEqual(['projectm:packZ/gone.milk']); // only the real pm orphan, never the unknowns
+  });
+
+  it('returns an empty array for an empty favorite set', () => {
+    expect(orphanedFavorites([], { projectmPaths: pmPaths, butterchurnNames: bcNames })).toEqual([]);
+    expect(orphanedFavorites(new Set<string>(), { projectmPaths: pmPaths })).toEqual([]);
   });
 });

--- a/src/utils/presetFavorites.ts
+++ b/src/utils/presetFavorites.ts
@@ -113,3 +113,46 @@ export function previousFavoriteIndex(favIndices: number[], currentIndex: number
   }
   return favIndices[favIndices.length - 1];
 }
+
+const PROJECTM_PREFIX = 'projectm:';
+const BUTTERCHURN_PREFIX = 'butterchurn:';
+
+/**
+ * Identify favorite keys that are *positively* orphaned — i.e. their preset is
+ * known to be absent from a **loaded** corpus for that key's engine.
+ *
+ * Safety is the entire point. A key is flagged ONLY when its engine's corpus is
+ * actually present and non-empty. If a corpus is absent or empty (e.g. the
+ * butterchurn presets aren't loaded because projectM/WebGPU is active, or the
+ * manifest hasn't loaded yet), that engine's keys are treated as "not
+ * evaluable" and are NEVER flagged — so callers can't wipe the inactive
+ * engine's favorites or delete during a load race. Unknown prefixes are never
+ * flagged. Pure: does not mutate input, touch storage, or call store actions —
+ * it only reads the corpora explicitly passed in.
+ *
+ * - projectM keys (`projectm:${path}`): orphaned iff `projectmPaths` is provided
+ *   and non-empty and does not contain the stripped path.
+ * - butterchurn keys (`butterchurn:${name}`): orphaned iff `butterchurnNames` is
+ *   provided and non-empty and does not contain the stripped name.
+ */
+export function orphanedFavorites(
+  favoriteKeys: Iterable<string>,
+  corpora: { projectmPaths?: Set<string>; butterchurnNames?: Set<string> },
+): string[] {
+  const { projectmPaths, butterchurnNames } = corpora;
+  const orphans: string[] = [];
+  for (const key of favoriteKeys) {
+    if (key.startsWith(PROJECTM_PREFIX)) {
+      // Evaluate only against a loaded (present + non-empty) projectM corpus.
+      if (projectmPaths && projectmPaths.size > 0 && !projectmPaths.has(key.slice(PROJECTM_PREFIX.length))) {
+        orphans.push(key);
+      }
+    } else if (key.startsWith(BUTTERCHURN_PREFIX)) {
+      if (butterchurnNames && butterchurnNames.size > 0 && !butterchurnNames.has(key.slice(BUTTERCHURN_PREFIX.length))) {
+        orphans.push(key);
+      }
+    }
+    // Unknown prefix → never flagged (no accidental deletion semantics).
+  }
+  return orphans;
+}


### PR DESCRIPTION
## Summary
Adds a pure, tested helper to safely identify *positively* orphaned visualizer favorite keys — **groundwork only**, no UI and no deletion.

- Adds pure **`orphanedFavorites(favoriteKeys, { projectmPaths?, butterchurnNames? })`** helper.
- Adds **13 safety tests**.
- Detection is **corpus-gated per engine**: a key is only evaluated against its engine's loaded corpus.
- **Absent or empty corpus → keys for that engine are not evaluable and are never flagged** (prevents cross-engine wipe and load-race deletion).
- **Unknown prefixes are not flagged.**
- Helper is **non-mutating** — reads only the passed-in corpora; no `localStorage`, no store actions.

## Out of scope / unchanged
- No UI. No cleanup button. No confirmation dialog. No count badge.
- No automatic deletion. No explicit deletion. No `removeFavorite`. No `localStorage` writes. No storage-shape change.
- No store / `PresetSearch` / `VisualizerScreen` changes.
- No favorite identity/storage changes.
- No search / ★ Only / next-previous / random / auto-advance / Shift+F / HUD ★ / `?preset=` changes.
- No rendering/crossfade/engine, dependency, workflow, Dockerfile, or release-metadata changes.

> **Groundwork only** — the helper is currently unused by any component and **should not trigger a standalone beta release**. It is intended to be held on `develop` until bundled with a user-facing item.

## Files changed (2)
- `src/utils/presetFavorites.ts`
- `src/utils/presetFavorites.test.ts`

## Test plan
- `npm run lint` — clean
- `npm run test:run` — 241/241 (+13)
- `npm run build` — succeeds
- `npm run test:smoke` — 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)