### PR TITLE
Add explicit orphaned-favorite cleanup UI

### DIFF
--- a/src/components/visualizer/PresetSearch.test.tsx
+++ b/src/components/visualizer/PresetSearch.test.tsx
@@ -97,4 +97,79 @@ describe('PresetSearch', () => {
     fireEvent.click(screen.getByLabelText('Show favorites only'));
     expect(screen.getByText('No favorited presets yet')).toBeInTheDocument();
   });
+
+  // --- orphan cleanup affordance ---
+
+  it('hides the cleanup affordance when orphanCount is 0 or omitted', () => {
+    const { rerender } = renderSearch();
+    expect(screen.queryByText('Clean up unavailable')).not.toBeInTheDocument();
+    rerender(
+      <PresetSearch
+        names={NAMES}
+        favoriteKeys={new Set()}
+        favoriteKeyForIndex={(i) => `fav:${i}`}
+        onToggleFavorite={() => {}}
+        onSelect={() => {}}
+        onClose={() => {}}
+        orphanCount={0}
+      />,
+    );
+    expect(screen.queryByText('Clean up unavailable')).not.toBeInTheDocument();
+  });
+
+  it('shows a singular count label', () => {
+    renderSearch({ orphanCount: 1, engineLabel: 'projectM' });
+    expect(screen.getByText('1 unavailable favorite')).toBeInTheDocument();
+    expect(screen.getByText('Clean up unavailable')).toBeInTheDocument();
+  });
+
+  it('shows a plural count label', () => {
+    renderSearch({ orphanCount: 3, engineLabel: 'projectM' });
+    expect(screen.getByText('3 unavailable favorites')).toBeInTheDocument();
+  });
+
+  it('clicking "Clean up unavailable" reveals the confirmation and does NOT delete', () => {
+    const onCleanupOrphans = vi.fn();
+    renderSearch({ orphanCount: 1, engineLabel: 'projectM', onCleanupOrphans });
+    fireEvent.click(screen.getByText('Clean up unavailable'));
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+    expect(screen.getByText('Remove')).toBeInTheDocument();
+    expect(onCleanupOrphans).not.toHaveBeenCalled(); // first click never deletes
+  });
+
+  it('confirmation text includes the engine label and count', () => {
+    renderSearch({ orphanCount: 2, engineLabel: 'projectM' });
+    fireEvent.click(screen.getByText('Clean up unavailable'));
+    expect(
+      screen.getByText(/Remove 2 unavailable projectM favorites from this device\?/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/only removes favorites that no longer match the loaded preset list/),
+    ).toBeInTheDocument();
+  });
+
+  it('Cancel hides the confirmation and calls nothing', () => {
+    const onCleanupOrphans = vi.fn();
+    renderSearch({ orphanCount: 1, engineLabel: 'projectM', onCleanupOrphans });
+    fireEvent.click(screen.getByText('Clean up unavailable'));
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onCleanupOrphans).not.toHaveBeenCalled();
+    expect(screen.queryByText('Remove')).not.toBeInTheDocument();
+    expect(screen.getByText('Clean up unavailable')).toBeInTheDocument(); // back to the affordance
+  });
+
+  it('Remove calls onCleanupOrphans exactly once', () => {
+    const onCleanupOrphans = vi.fn();
+    renderSearch({ orphanCount: 1, engineLabel: 'projectM', onCleanupOrphans });
+    fireEvent.click(screen.getByText('Clean up unavailable'));
+    fireEvent.click(screen.getByText('Remove'));
+    expect(onCleanupOrphans).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps normal row-star behavior unchanged when the cleanup affordance is present', () => {
+    const onToggleFavorite = vi.fn();
+    renderSearch({ orphanCount: 1, engineLabel: 'projectM', onToggleFavorite });
+    fireEvent.click(screen.getAllByLabelText('Favorite preset')[0]);
+    expect(onToggleFavorite).toHaveBeenCalledWith('fav:0');
+  });
 });

--- a/src/components/visualizer/PresetSearch.tsx
+++ b/src/components/visualizer/PresetSearch.tsx
@@ -26,6 +26,12 @@ interface PresetSearchProps {
   /** Called with the ORIGINAL index into `names` for the chosen preset. */
   onSelect: (index: number) => void;
   onClose: () => void;
+  /** Count of active-engine favorites that no longer resolve to a preset. */
+  orphanCount?: number;
+  /** Active engine label for the cleanup confirmation copy (e.g. 'projectM'). */
+  engineLabel?: string;
+  /** Remove the active-engine orphans (caller recomputes + bulk-removes). */
+  onCleanupOrphans?: () => void;
 }
 
 export default function PresetSearch({
@@ -35,10 +41,14 @@ export default function PresetSearch({
   onToggleFavorite,
   onSelect,
   onClose,
+  orphanCount = 0,
+  engineLabel,
+  onCleanupOrphans,
 }: PresetSearchProps) {
   const [query, setQuery] = useState('');
   const [highlight, setHighlight] = useState(0);
   const [favoritesOnly, setFavoritesOnly] = useState(false);
+  const [confirmingCleanup, setConfirmingCleanup] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
 
@@ -208,6 +218,51 @@ export default function PresetSearch({
         {overflow > 0 && (
           <div className="border-t border-white/10 px-4 py-2 text-xs text-white/50">
             Showing {shown.length} of {matches.length} — refine your search to narrow results.
+          </div>
+        )}
+        {orphanCount > 0 && (
+          <div className="border-t border-white/10 px-4 py-2 text-xs">
+            {!confirmingCleanup ? (
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-white/50">
+                  {orphanCount === 1 ? '1 unavailable favorite' : `${orphanCount} unavailable favorites`}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setConfirmingCleanup(true)}
+                  className="shrink-0 rounded-full bg-white/10 px-3 py-1 text-white/70 hover:text-white"
+                >
+                  Clean up unavailable
+                </button>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                <span className="text-white/70">
+                  {`Remove ${orphanCount} unavailable ${engineLabel ? `${engineLabel} ` : ''}favorite${
+                    orphanCount === 1 ? '' : 's'
+                  } from this device? This only removes favorites that no longer match the loaded preset list.`}
+                </span>
+                <div className="flex items-center justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setConfirmingCleanup(false)}
+                    className="rounded-full bg-white/10 px-3 py-1 text-white/70 hover:text-white"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onCleanupOrphans?.();
+                      setConfirmingCleanup(false);
+                    }}
+                    className="rounded-full bg-red-500/30 px-3 py-1 text-white hover:bg-red-500/40"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -17,6 +17,7 @@ import {
   randomFavoriteIndex,
   nextFavoriteIndex,
   previousFavoriteIndex,
+  orphanedFavorites,
 } from '../utils/presetFavorites';
 import type { PresetIndexEntry } from '../types/presets';
 
@@ -338,6 +339,7 @@ export default function VisualizerScreen() {
   // Local preset favorites (engine-prefixed keys; persisted to localStorage).
   const favoriteKeys = usePresetFavoritesStore((s) => s.favoriteKeys);
   const toggleFavorite = usePresetFavoritesStore((s) => s.toggleFavorite);
+  const removeFavorites = usePresetFavoritesStore((s) => s.removeFavorites);
   const favoriteKeyForIndex = useCallback(
     (index: number) => resolveFavoriteKey(milkdropEngine, index, milkdropEntries, milkdropPresetNames),
     [milkdropEngine, milkdropEntries, milkdropPresetNames],
@@ -898,6 +900,30 @@ export default function VisualizerScreen() {
     [milkdropPresetNames, favoriteKeys, favoriteKeyForIndex],
   );
   const hasActiveFavorites = favoritedIndices.length > 0;
+
+  // Active-engine orphan favorites: keys whose preset is no longer in the loaded
+  // corpus FOR THE ACTIVE ENGINE only. We pass *only* the active engine's corpus
+  // to orphanedFavorites, so the inactive engine's keys are never evaluable and
+  // can never be counted or removed (no cross-engine wipe, no load-race wipe).
+  const computeOrphanFavorites = useCallback((): string[] => {
+    if (mode !== 'milkdrop' || !milkdropReady) return [];
+    if (milkdropEngine === 'projectm') {
+      return orphanedFavorites(favoriteKeys, { projectmPaths: new Set(milkdropEntries.map((e) => e.path)) });
+    }
+    if (milkdropEngine === 'butterchurn') {
+      return orphanedFavorites(favoriteKeys, { butterchurnNames: new Set(milkdropPresetNames) });
+    }
+    return [];
+  }, [mode, milkdropReady, milkdropEngine, milkdropEntries, milkdropPresetNames, favoriteKeys]);
+  const orphanFavoriteCount = useMemo(() => computeOrphanFavorites().length, [computeOrphanFavorites]);
+  const orphanEngineLabel =
+    milkdropEngine === 'projectm' ? 'projectM' : milkdropEngine === 'butterchurn' ? 'butterchurn' : undefined;
+  // Recompute fresh at click time so cleanup never acts on a stale list.
+  const handleCleanupOrphans = useCallback(() => {
+    const keys = computeOrphanFavorites();
+    if (keys.length > 0) removeFavorites(keys);
+  }, [computeOrphanFavorites, removeFavorites]);
+
   // Refs so the interval-captured auto-advance always reads current values
   // (favorites can change while it runs without re-subscribing the interval).
   const favoritesOnlyRef = useRef(visualizerFavoritesOnly);
@@ -1347,6 +1373,9 @@ export default function VisualizerScreen() {
             setPresetSearchOpen(false);
           }}
           onClose={() => setPresetSearchOpen(false)}
+          orphanCount={orphanFavoriteCount}
+          engineLabel={orphanEngineLabel}
+          onCleanupOrphans={handleCleanupOrphans}
         />
       )}
     </div>

--- a/src/stores/presetFavoritesStore.test.ts
+++ b/src/stores/presetFavoritesStore.test.ts
@@ -68,4 +68,61 @@ describe('presetFavoritesStore', () => {
     expect(loadFavorites().size).toBe(1); // non-strings filtered out
     expect(loadFavorites().has('projectm:ok')).toBe(true);
   });
+
+  describe('removeFavorites (bulk)', () => {
+    const seed = (keys: string[]) => {
+      const s = usePresetFavoritesStore.getState();
+      keys.forEach((k) => s.addFavorite(k));
+    };
+
+    it('removes exactly the requested keys and leaves the rest', () => {
+      seed(['projectm:a', 'projectm:b', 'projectm:c', 'butterchurn:x']);
+      usePresetFavoritesStore.getState().removeFavorites(['projectm:a', 'projectm:c']);
+      const keys = usePresetFavoritesStore.getState().favoriteKeys;
+      expect([...keys].sort()).toEqual(['butterchurn:x', 'projectm:b']);
+    });
+
+    it('does not throw when asked to remove absent keys, and leaves others intact', () => {
+      seed(['projectm:a', 'butterchurn:x']);
+      expect(() =>
+        usePresetFavoritesStore.getState().removeFavorites(['projectm:ghost', 'nope:none']),
+      ).not.toThrow();
+      expect([...usePresetFavoritesStore.getState().favoriteKeys].sort()).toEqual([
+        'butterchurn:x',
+        'projectm:a',
+      ]);
+    });
+
+    it('is a no-op for an empty iterable (state ref unchanged → no set())', () => {
+      seed(['projectm:a']);
+      const before = usePresetFavoritesStore.getState().favoriteKeys;
+      usePresetFavoritesStore.getState().removeFavorites([]);
+      expect(usePresetFavoritesStore.getState().favoriteKeys).toBe(before);
+    });
+
+    it('is a no-op when none of the keys are present (no state churn)', () => {
+      seed(['projectm:a']);
+      const before = usePresetFavoritesStore.getState().favoriteKeys;
+      usePresetFavoritesStore.getState().removeFavorites(['projectm:ghost']);
+      expect(usePresetFavoritesStore.getState().favoriteKeys).toBe(before);
+    });
+
+    it('persists the surviving keys once, in the versioned shape', () => {
+      seed(['projectm:a', 'projectm:b', 'butterchurn:x']);
+      usePresetFavoritesStore.getState().removeFavorites(['projectm:b']);
+      const raw = localStorage.getItem(STORAGE_KEY);
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw!);
+      expect(parsed.v).toBe(1);
+      expect([...parsed.keys].sort()).toEqual(['butterchurn:x', 'projectm:a']);
+      // round-trips back into a Set with exactly the survivors
+      expect([...loadFavorites()].sort()).toEqual(['butterchurn:x', 'projectm:a']);
+    });
+
+    it('accepts a Set as input', () => {
+      seed(['projectm:a', 'projectm:b']);
+      usePresetFavoritesStore.getState().removeFavorites(new Set(['projectm:a']));
+      expect([...usePresetFavoritesStore.getState().favoriteKeys]).toEqual(['projectm:b']);
+    });
+  });
 });

--- a/src/stores/presetFavoritesStore.ts
+++ b/src/stores/presetFavoritesStore.ts
@@ -37,6 +37,7 @@ interface PresetFavoritesState {
   isFavorite: (key: string) => boolean;
   addFavorite: (key: string) => void;
   removeFavorite: (key: string) => void;
+  removeFavorites: (keys: Iterable<string>) => void;
   toggleFavorite: (key: string) => void;
 }
 
@@ -54,6 +55,18 @@ export const usePresetFavoritesStore = create<PresetFavoritesState>((set, get) =
     if (!get().favoriteKeys.has(key)) return;
     const next = new Set(get().favoriteKeys);
     next.delete(key);
+    persist(next);
+    set({ favoriteKeys: next });
+  },
+  // Atomic bulk removal (one persist + one state update). No-op if nothing in
+  // `keys` was actually present — used by explicit orphan cleanup.
+  removeFavorites: (keys) => {
+    const next = new Set(get().favoriteKeys);
+    let changed = false;
+    for (const key of keys) {
+      if (next.delete(key)) changed = true;
+    }
+    if (!changed) return;
     persist(next);
     set({ favoriteKeys: next });
   },


### PR DESCRIPTION
## Summary
Turns the merged `orphanedFavorites(...)` groundwork (PR #77) into safe, **explicit, confirmed** cleanup for unavailable visualizer favorites.

- Adds an explicit **cleanup UI** for unavailable favorites in the PresetSearch overlay.
- Uses the existing **`orphanedFavorites(...)`** helper.
- Adds a **`removeFavorites(keys)`** atomic bulk store action (one persist + one state update; no-op when nothing matches).
- Cleanup is **active-engine scoped** — only the active engine's loaded corpus is passed to the helper.
- Cleanup is shown **only when active-engine orphans exist** (hidden at count 0).
- Cleanup **requires confirmation** (inline `Remove` / `Cancel`).
- **No automatic deletion.** No cleanup on app load. No cleanup on search-open without user action.
- Removes **only keys recomputed as active-engine orphans at click time**.
- **Valid favorites remain. Inactive-engine favorites remain. Unknown-prefix keys remain.**
- Storage shape remains `{ v: 1, keys: [...] }` — no migration.

## Out of scope / unchanged
- No sync/backend. No dependency / workflow / Dockerfile / projectM-rs / `src/pmweb/*` changes. No rendering/crossfade/engine changes. No release metadata.
- No changes to search selection, ★ Only, next/previous, random, auto-advance, Shift+F, HUD ★, or `?preset=`.

## Files changed (5)
- `src/stores/presetFavoritesStore.ts` (+ `.test.ts`) — bulk `removeFavorites`
- `src/components/visualizer/PresetSearch.tsx` (+ `.test.tsx`) — cleanup affordance + inline confirm
- `src/screens/VisualizerScreen.tsx` — active-engine orphan computation + recompute-at-click handler + wiring

## Test plan
- `npm run lint` — clean
- `npm run test:run` — 255/255 (+14: 6 store, 8 PresetSearch)
- `npm run build` — succeeds
- `npm run test:smoke` — 0 console errors
- Manual (real Chrome, projectM/WebGPU, epilepsy gate seeded; mixed favorites = valid pm + invalid pm + butterchurn): shows exactly "1 unavailable favorite" (butterchurn not counted); Cancel deletes nothing; Remove deletes only the invalid projectM key (valid pm + butterchurn survive); affordance disappears after; 0 console errors.

## Release note
This PR **plus the held PR #77 helper** should be bundled into a future **beta.14**. (No beta.14 metadata in this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)