### PR TITLE
Prepare v1.9.0-beta.14 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.14] - 2026-06-21
+
+### Added
+- **Explicit cleanup for unavailable visualizer favorites** — tidy favorites whose presets are no longer in the loaded list.
+- **Safe orphaned-favorite detection helper** used by the cleanup.
+
+### Notes
+- Cleanup appears in PresetSearch **only when active-engine unavailable favorites are detected**.
+- Cleanup is **user-initiated and requires confirmation**.
+- Cleanup removes **only positively detected unavailable favorites for the active engine**.
+- **Inactive-engine favorites are not counted or removed.**
+- **Valid favorites are not removed.**
+- **Unknown-prefix favorites are not removed.**
+- **No automatic cleanup** on app load or search open.
+- Favorite storage shape remains `{ v: 1, keys: [...] }`.
+- **Search, ★ Only, next/previous, random, auto-advance, HUD ★, Shift+F, and `?preset=` are unchanged.**
+- No rendering, engine, crossfade, preset-bundle, dependency, workflow, or Dockerfile changes.
+- Deferred (not in this release): cross-device sync.
+
 ## [1.9.0-beta.13] - 2026-06-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.13",
+  "version": "1.9.0-beta.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.13",
+      "version": "1.9.0-beta.14",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.13",
+  "version": "1.9.0-beta.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.13</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.14</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">


### PR DESCRIPTION
## Summary

Release metadata for **v1.9.0-beta.14**, shipping the orphaned-favorite cleanup feature staged on `develop` — bundles **PR #77** (detection helper) + **PR #78** (explicit cleanup UI).

- **Version bump** `1.9.0-beta.13` → `1.9.0-beta.14` (`package.json`, `package-lock.json` root + `packages[""]`, `SettingsScreen` About string).
- **CHANGELOG** entry for explicit orphaned-favorite cleanup.
- Bundles **PR #77 + PR #78**.
- **No dependency changes** (lockfile touches only the two version fields).
- **No workflow / Dockerfile changes.**
- **No engine / projectM changes. No sync/backend.**
- **No release/deploy yet** — metadata only.

## Files changed (4)
- `package.json`
- `package-lock.json`
- `src/screens/SettingsScreen.tsx`
- `CHANGELOG.md`

## CHANGELOG [1.9.0-beta.14]
Added: explicit cleanup for unavailable visualizer favorites; safe orphaned-favorite detection helper used by cleanup. Notes: cleanup appears in PresetSearch only when active-engine unavailable favorites are detected; user-initiated + requires confirmation; removes only positively detected active-engine orphans; inactive-engine favorites not counted/removed; valid favorites not removed; unknown-prefix favorites not removed; no automatic cleanup on app load or search open; storage shape remains `{ v: 1, keys: [...] }`; search, ★ Only, next/previous, random, auto-advance, HUD ★, Shift+F, and `?preset=` unchanged; no rendering/engine/crossfade/preset-bundle/dependency/workflow/Dockerfile changes. Deferred: cross-device sync.

## Test plan
- `npm run lint` — clean
- `npm run test:run` — 255/255
- `npm run build` — succeeds
- `npm run test:smoke` — 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)