### PR TITLE
Release v1.9.0-beta.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.14] - 2026-06-21
+
+### Added
+- **Explicit cleanup for unavailable visualizer favorites** — tidy favorites whose presets are no longer in the loaded list.
+- **Safe orphaned-favorite detection helper** used by the cleanup.
+
+### Notes
+- Cleanup appears in PresetSearch **only when active-engine unavailable favorites are detected**.
+- Cleanup is **user-initiated and requires confirmation**.
+- Cleanup removes **only positively detected unavailable favorites for the active engine**.
+- **Inactive-engine favorites are not counted or removed.**
+- **Valid favorites are not removed.**
+- **Unknown-prefix favorites are not removed.**
+- **No automatic cleanup** on app load or search open.
+- Favorite storage shape remains `{ v: 1, keys: [...] }`.
+- **Search, ★ Only, next/previous, random, auto-advance, HUD ★, Shift+F, and `?preset=` are unchanged.**
+- No rendering, engine, crossfade, preset-bundle, dependency, workflow, or Dockerfile changes.
+- Deferred (not in this release): cross-device sync.
+
 ## [1.9.0-beta.13] - 2026-06-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.13",
+  "version": "1.9.0-beta.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.13",
+      "version": "1.9.0-beta.14",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.13",
+  "version": "1.9.0-beta.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/visualizer/PresetSearch.test.tsx
+++ b/src/components/visualizer/PresetSearch.test.tsx
@@ -97,4 +97,79 @@ describe('PresetSearch', () => {
     fireEvent.click(screen.getByLabelText('Show favorites only'));
     expect(screen.getByText('No favorited presets yet')).toBeInTheDocument();
   });
+
+  // --- orphan cleanup affordance ---
+
+  it('hides the cleanup affordance when orphanCount is 0 or omitted', () => {
+    const { rerender } = renderSearch();
+    expect(screen.queryByText('Clean up unavailable')).not.toBeInTheDocument();
+    rerender(
+      <PresetSearch
+        names={NAMES}
+        favoriteKeys={new Set()}
+        favoriteKeyForIndex={(i) => `fav:${i}`}
+        onToggleFavorite={() => {}}
+        onSelect={() => {}}
+        onClose={() => {}}
+        orphanCount={0}
+      />,
+    );
+    expect(screen.queryByText('Clean up unavailable')).not.toBeInTheDocument();
+  });
+
+  it('shows a singular count label', () => {
+    renderSearch({ orphanCount: 1, engineLabel: 'projectM' });
+    expect(screen.getByText('1 unavailable favorite')).toBeInTheDocument();
+    expect(screen.getByText('Clean up unavailable')).toBeInTheDocument();
+  });
+
+  it('shows a plural count label', () => {
+    renderSearch({ orphanCount: 3, engineLabel: 'projectM' });
+    expect(screen.getByText('3 unavailable favorites')).toBeInTheDocument();
+  });
+
+  it('clicking "Clean up unavailable" reveals the confirmation and does NOT delete', () => {
+    const onCleanupOrphans = vi.fn();
+    renderSearch({ orphanCount: 1, engineLabel: 'projectM', onCleanupOrphans });
+    fireEvent.click(screen.getByText('Clean up unavailable'));
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+    expect(screen.getByText('Remove')).toBeInTheDocument();
+    expect(onCleanupOrphans).not.toHaveBeenCalled(); // first click never deletes
+  });
+
+  it('confirmation text includes the engine label and count', () => {
+    renderSearch({ orphanCount: 2, engineLabel: 'projectM' });
+    fireEvent.click(screen.getByText('Clean up unavailable'));
+    expect(
+      screen.getByText(/Remove 2 unavailable projectM favorites from this device\?/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/only removes favorites that no longer match the loaded preset list/),
+    ).toBeInTheDocument();
+  });
+
+  it('Cancel hides the confirmation and calls nothing', () => {
+    const onCleanupOrphans = vi.fn();
+    renderSearch({ orphanCount: 1, engineLabel: 'projectM', onCleanupOrphans });
+    fireEvent.click(screen.getByText('Clean up unavailable'));
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onCleanupOrphans).not.toHaveBeenCalled();
+    expect(screen.queryByText('Remove')).not.toBeInTheDocument();
+    expect(screen.getByText('Clean up unavailable')).toBeInTheDocument(); // back to the affordance
+  });
+
+  it('Remove calls onCleanupOrphans exactly once', () => {
+    const onCleanupOrphans = vi.fn();
+    renderSearch({ orphanCount: 1, engineLabel: 'projectM', onCleanupOrphans });
+    fireEvent.click(screen.getByText('Clean up unavailable'));
+    fireEvent.click(screen.getByText('Remove'));
+    expect(onCleanupOrphans).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps normal row-star behavior unchanged when the cleanup affordance is present', () => {
+    const onToggleFavorite = vi.fn();
+    renderSearch({ orphanCount: 1, engineLabel: 'projectM', onToggleFavorite });
+    fireEvent.click(screen.getAllByLabelText('Favorite preset')[0]);
+    expect(onToggleFavorite).toHaveBeenCalledWith('fav:0');
+  });
 });

--- a/src/components/visualizer/PresetSearch.tsx
+++ b/src/components/visualizer/PresetSearch.tsx
@@ -26,6 +26,12 @@ interface PresetSearchProps {
   /** Called with the ORIGINAL index into `names` for the chosen preset. */
   onSelect: (index: number) => void;
   onClose: () => void;
+  /** Count of active-engine favorites that no longer resolve to a preset. */
+  orphanCount?: number;
+  /** Active engine label for the cleanup confirmation copy (e.g. 'projectM'). */
+  engineLabel?: string;
+  /** Remove the active-engine orphans (caller recomputes + bulk-removes). */
+  onCleanupOrphans?: () => void;
 }
 
 export default function PresetSearch({
@@ -35,10 +41,14 @@ export default function PresetSearch({
   onToggleFavorite,
   onSelect,
   onClose,
+  orphanCount = 0,
+  engineLabel,
+  onCleanupOrphans,
 }: PresetSearchProps) {
   const [query, setQuery] = useState('');
   const [highlight, setHighlight] = useState(0);
   const [favoritesOnly, setFavoritesOnly] = useState(false);
+  const [confirmingCleanup, setConfirmingCleanup] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
 
@@ -208,6 +218,51 @@ export default function PresetSearch({
         {overflow > 0 && (
           <div className="border-t border-white/10 px-4 py-2 text-xs text-white/50">
             Showing {shown.length} of {matches.length} — refine your search to narrow results.
+          </div>
+        )}
+        {orphanCount > 0 && (
+          <div className="border-t border-white/10 px-4 py-2 text-xs">
+            {!confirmingCleanup ? (
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-white/50">
+                  {orphanCount === 1 ? '1 unavailable favorite' : `${orphanCount} unavailable favorites`}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setConfirmingCleanup(true)}
+                  className="shrink-0 rounded-full bg-white/10 px-3 py-1 text-white/70 hover:text-white"
+                >
+                  Clean up unavailable
+                </button>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                <span className="text-white/70">
+                  {`Remove ${orphanCount} unavailable ${engineLabel ? `${engineLabel} ` : ''}favorite${
+                    orphanCount === 1 ? '' : 's'
+                  } from this device? This only removes favorites that no longer match the loaded preset list.`}
+                </span>
+                <div className="flex items-center justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setConfirmingCleanup(false)}
+                    className="rounded-full bg-white/10 px-3 py-1 text-white/70 hover:text-white"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onCleanupOrphans?.();
+                      setConfirmingCleanup(false);
+                    }}
+                    className="rounded-full bg-red-500/30 px-3 py-1 text-white hover:bg-red-500/40"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -648,7 +648,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.13</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.14</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -17,6 +17,7 @@ import {
   randomFavoriteIndex,
   nextFavoriteIndex,
   previousFavoriteIndex,
+  orphanedFavorites,
 } from '../utils/presetFavorites';
 import type { PresetIndexEntry } from '../types/presets';
 
@@ -338,6 +339,7 @@ export default function VisualizerScreen() {
   // Local preset favorites (engine-prefixed keys; persisted to localStorage).
   const favoriteKeys = usePresetFavoritesStore((s) => s.favoriteKeys);
   const toggleFavorite = usePresetFavoritesStore((s) => s.toggleFavorite);
+  const removeFavorites = usePresetFavoritesStore((s) => s.removeFavorites);
   const favoriteKeyForIndex = useCallback(
     (index: number) => resolveFavoriteKey(milkdropEngine, index, milkdropEntries, milkdropPresetNames),
     [milkdropEngine, milkdropEntries, milkdropPresetNames],
@@ -898,6 +900,30 @@ export default function VisualizerScreen() {
     [milkdropPresetNames, favoriteKeys, favoriteKeyForIndex],
   );
   const hasActiveFavorites = favoritedIndices.length > 0;
+
+  // Active-engine orphan favorites: keys whose preset is no longer in the loaded
+  // corpus FOR THE ACTIVE ENGINE only. We pass *only* the active engine's corpus
+  // to orphanedFavorites, so the inactive engine's keys are never evaluable and
+  // can never be counted or removed (no cross-engine wipe, no load-race wipe).
+  const computeOrphanFavorites = useCallback((): string[] => {
+    if (mode !== 'milkdrop' || !milkdropReady) return [];
+    if (milkdropEngine === 'projectm') {
+      return orphanedFavorites(favoriteKeys, { projectmPaths: new Set(milkdropEntries.map((e) => e.path)) });
+    }
+    if (milkdropEngine === 'butterchurn') {
+      return orphanedFavorites(favoriteKeys, { butterchurnNames: new Set(milkdropPresetNames) });
+    }
+    return [];
+  }, [mode, milkdropReady, milkdropEngine, milkdropEntries, milkdropPresetNames, favoriteKeys]);
+  const orphanFavoriteCount = useMemo(() => computeOrphanFavorites().length, [computeOrphanFavorites]);
+  const orphanEngineLabel =
+    milkdropEngine === 'projectm' ? 'projectM' : milkdropEngine === 'butterchurn' ? 'butterchurn' : undefined;
+  // Recompute fresh at click time so cleanup never acts on a stale list.
+  const handleCleanupOrphans = useCallback(() => {
+    const keys = computeOrphanFavorites();
+    if (keys.length > 0) removeFavorites(keys);
+  }, [computeOrphanFavorites, removeFavorites]);
+
   // Refs so the interval-captured auto-advance always reads current values
   // (favorites can change while it runs without re-subscribing the interval).
   const favoritesOnlyRef = useRef(visualizerFavoritesOnly);
@@ -1347,6 +1373,9 @@ export default function VisualizerScreen() {
             setPresetSearchOpen(false);
           }}
           onClose={() => setPresetSearchOpen(false)}
+          orphanCount={orphanFavoriteCount}
+          engineLabel={orphanEngineLabel}
+          onCleanupOrphans={handleCleanupOrphans}
         />
       )}
     </div>

--- a/src/stores/presetFavoritesStore.test.ts
+++ b/src/stores/presetFavoritesStore.test.ts
@@ -68,4 +68,61 @@ describe('presetFavoritesStore', () => {
     expect(loadFavorites().size).toBe(1); // non-strings filtered out
     expect(loadFavorites().has('projectm:ok')).toBe(true);
   });
+
+  describe('removeFavorites (bulk)', () => {
+    const seed = (keys: string[]) => {
+      const s = usePresetFavoritesStore.getState();
+      keys.forEach((k) => s.addFavorite(k));
+    };
+
+    it('removes exactly the requested keys and leaves the rest', () => {
+      seed(['projectm:a', 'projectm:b', 'projectm:c', 'butterchurn:x']);
+      usePresetFavoritesStore.getState().removeFavorites(['projectm:a', 'projectm:c']);
+      const keys = usePresetFavoritesStore.getState().favoriteKeys;
+      expect([...keys].sort()).toEqual(['butterchurn:x', 'projectm:b']);
+    });
+
+    it('does not throw when asked to remove absent keys, and leaves others intact', () => {
+      seed(['projectm:a', 'butterchurn:x']);
+      expect(() =>
+        usePresetFavoritesStore.getState().removeFavorites(['projectm:ghost', 'nope:none']),
+      ).not.toThrow();
+      expect([...usePresetFavoritesStore.getState().favoriteKeys].sort()).toEqual([
+        'butterchurn:x',
+        'projectm:a',
+      ]);
+    });
+
+    it('is a no-op for an empty iterable (state ref unchanged → no set())', () => {
+      seed(['projectm:a']);
+      const before = usePresetFavoritesStore.getState().favoriteKeys;
+      usePresetFavoritesStore.getState().removeFavorites([]);
+      expect(usePresetFavoritesStore.getState().favoriteKeys).toBe(before);
+    });
+
+    it('is a no-op when none of the keys are present (no state churn)', () => {
+      seed(['projectm:a']);
+      const before = usePresetFavoritesStore.getState().favoriteKeys;
+      usePresetFavoritesStore.getState().removeFavorites(['projectm:ghost']);
+      expect(usePresetFavoritesStore.getState().favoriteKeys).toBe(before);
+    });
+
+    it('persists the surviving keys once, in the versioned shape', () => {
+      seed(['projectm:a', 'projectm:b', 'butterchurn:x']);
+      usePresetFavoritesStore.getState().removeFavorites(['projectm:b']);
+      const raw = localStorage.getItem(STORAGE_KEY);
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw!);
+      expect(parsed.v).toBe(1);
+      expect([...parsed.keys].sort()).toEqual(['butterchurn:x', 'projectm:a']);
+      // round-trips back into a Set with exactly the survivors
+      expect([...loadFavorites()].sort()).toEqual(['butterchurn:x', 'projectm:a']);
+    });
+
+    it('accepts a Set as input', () => {
+      seed(['projectm:a', 'projectm:b']);
+      usePresetFavoritesStore.getState().removeFavorites(new Set(['projectm:a']));
+      expect([...usePresetFavoritesStore.getState().favoriteKeys]).toEqual(['projectm:b']);
+    });
+  });
 });

--- a/src/stores/presetFavoritesStore.ts
+++ b/src/stores/presetFavoritesStore.ts
@@ -37,6 +37,7 @@ interface PresetFavoritesState {
   isFavorite: (key: string) => boolean;
   addFavorite: (key: string) => void;
   removeFavorite: (key: string) => void;
+  removeFavorites: (keys: Iterable<string>) => void;
   toggleFavorite: (key: string) => void;
 }
 
@@ -54,6 +55,18 @@ export const usePresetFavoritesStore = create<PresetFavoritesState>((set, get) =
     if (!get().favoriteKeys.has(key)) return;
     const next = new Set(get().favoriteKeys);
     next.delete(key);
+    persist(next);
+    set({ favoriteKeys: next });
+  },
+  // Atomic bulk removal (one persist + one state update). No-op if nothing in
+  // `keys` was actually present — used by explicit orphan cleanup.
+  removeFavorites: (keys) => {
+    const next = new Set(get().favoriteKeys);
+    let changed = false;
+    for (const key of keys) {
+      if (next.delete(key)) changed = true;
+    }
+    if (!changed) return;
     persist(next);
     set({ favoriteKeys: next });
   },

--- a/src/utils/presetFavorites.test.ts
+++ b/src/utils/presetFavorites.test.ts
@@ -7,6 +7,7 @@ import {
   randomFavoriteIndex,
   nextFavoriteIndex,
   previousFavoriteIndex,
+  orphanedFavorites,
 } from './presetFavorites';
 import type { PresetIndexEntry } from '../types/presets';
 
@@ -142,5 +143,94 @@ describe('favoritedIndicesIn ascending order', () => {
     const keyForIndex = (i: number) => `k:${i}`;
     const favs = new Set(['k:4', 'k:1', 'k:3']); // out-of-order set
     expect(favoritedIndicesIn(names, favs, keyForIndex)).toEqual([1, 3, 4]); // ascending
+  });
+});
+
+describe('orphanedFavorites', () => {
+  const pmPaths = new Set(['packA/cool.milk', 'packB/warm.milk']);
+  const bcNames = new Set(['Flexi - mom', 'Geiss - Cosmic']);
+
+  it('does NOT flag a valid projectM key when the projectM corpus is loaded', () => {
+    expect(orphanedFavorites(['projectm:packA/cool.milk'], { projectmPaths: pmPaths })).toEqual([]);
+  });
+
+  it('detects an invalid projectM key when the projectM corpus is loaded', () => {
+    expect(orphanedFavorites(['projectm:packZ/gone.milk'], { projectmPaths: pmPaths })).toEqual([
+      'projectm:packZ/gone.milk',
+    ]);
+  });
+
+  it('does NOT evaluate projectM keys when projectmPaths is absent (corpus not loaded)', () => {
+    expect(orphanedFavorites(['projectm:packZ/gone.milk'], {})).toEqual([]);
+    expect(orphanedFavorites(['projectm:packZ/gone.milk'], { butterchurnNames: bcNames })).toEqual([]);
+  });
+
+  it('does NOT evaluate projectM keys when projectmPaths is empty (load race)', () => {
+    expect(orphanedFavorites(['projectm:packZ/gone.milk'], { projectmPaths: new Set() })).toEqual([]);
+  });
+
+  it('does NOT flag a valid butterchurn key when the butterchurn corpus is loaded', () => {
+    expect(orphanedFavorites(['butterchurn:Flexi - mom'], { butterchurnNames: bcNames })).toEqual([]);
+  });
+
+  it('detects an invalid butterchurn key when the butterchurn corpus is loaded', () => {
+    expect(orphanedFavorites(['butterchurn:Deleted - preset'], { butterchurnNames: bcNames })).toEqual([
+      'butterchurn:Deleted - preset',
+    ]);
+  });
+
+  it('does NOT evaluate butterchurn keys when butterchurnNames is absent (corpus not loaded)', () => {
+    expect(orphanedFavorites(['butterchurn:Deleted - preset'], {})).toEqual([]);
+    expect(orphanedFavorites(['butterchurn:Deleted - preset'], { projectmPaths: pmPaths })).toEqual([]);
+  });
+
+  it('does NOT evaluate butterchurn keys when butterchurnNames is empty (load race)', () => {
+    expect(orphanedFavorites(['butterchurn:Deleted - preset'], { butterchurnNames: new Set() })).toEqual([]);
+  });
+
+  it('with mixed favorites, only flags keys for engines whose corpus is loaded', () => {
+    // projectM corpus loaded, butterchurn corpus NOT loaded.
+    const favs = [
+      'projectm:packA/cool.milk', // valid pm → not flagged
+      'projectm:packZ/gone.milk', // invalid pm → flagged
+      'butterchurn:Flexi - mom', // bc corpus absent → not evaluable
+      'butterchurn:Deleted - preset', // bc corpus absent → not evaluable
+    ];
+    expect(orphanedFavorites(favs, { projectmPaths: pmPaths })).toEqual(['projectm:packZ/gone.milk']);
+  });
+
+  it('never flags inactive/absent-engine favorites even when they would be invalid', () => {
+    // A butterchurn-only session: projectM corpus absent. The (invalid-looking)
+    // projectM key must be left untouched — we cannot see its corpus.
+    expect(
+      orphanedFavorites(['projectm:packZ/gone.milk', 'butterchurn:Flexi - mom'], {
+        butterchurnNames: bcNames,
+      }),
+    ).toEqual([]);
+  });
+
+  it('does not mutate its inputs', () => {
+    const favs = ['projectm:packZ/gone.milk', 'butterchurn:Flexi - mom'];
+    const favsCopy = [...favs];
+    const pm = new Set(pmPaths);
+    const bc = new Set(bcNames);
+    orphanedFavorites(favs, { projectmPaths: pm, butterchurnNames: bc });
+    expect(favs).toEqual(favsCopy);
+    expect([...pm]).toEqual([...pmPaths]);
+    expect([...bc]).toEqual([...bcNames]);
+  });
+
+  it('never flags unknown-prefix keys', () => {
+    expect(
+      orphanedFavorites(['weird:thing', 'no-prefix', 'projectm:packZ/gone.milk'], {
+        projectmPaths: pmPaths,
+        butterchurnNames: bcNames,
+      }),
+    ).toEqual(['projectm:packZ/gone.milk']); // only the real pm orphan, never the unknowns
+  });
+
+  it('returns an empty array for an empty favorite set', () => {
+    expect(orphanedFavorites([], { projectmPaths: pmPaths, butterchurnNames: bcNames })).toEqual([]);
+    expect(orphanedFavorites(new Set<string>(), { projectmPaths: pmPaths })).toEqual([]);
   });
 });

--- a/src/utils/presetFavorites.ts
+++ b/src/utils/presetFavorites.ts
@@ -113,3 +113,46 @@ export function previousFavoriteIndex(favIndices: number[], currentIndex: number
   }
   return favIndices[favIndices.length - 1];
 }
+
+const PROJECTM_PREFIX = 'projectm:';
+const BUTTERCHURN_PREFIX = 'butterchurn:';
+
+/**
+ * Identify favorite keys that are *positively* orphaned — i.e. their preset is
+ * known to be absent from a **loaded** corpus for that key's engine.
+ *
+ * Safety is the entire point. A key is flagged ONLY when its engine's corpus is
+ * actually present and non-empty. If a corpus is absent or empty (e.g. the
+ * butterchurn presets aren't loaded because projectM/WebGPU is active, or the
+ * manifest hasn't loaded yet), that engine's keys are treated as "not
+ * evaluable" and are NEVER flagged — so callers can't wipe the inactive
+ * engine's favorites or delete during a load race. Unknown prefixes are never
+ * flagged. Pure: does not mutate input, touch storage, or call store actions —
+ * it only reads the corpora explicitly passed in.
+ *
+ * - projectM keys (`projectm:${path}`): orphaned iff `projectmPaths` is provided
+ *   and non-empty and does not contain the stripped path.
+ * - butterchurn keys (`butterchurn:${name}`): orphaned iff `butterchurnNames` is
+ *   provided and non-empty and does not contain the stripped name.
+ */
+export function orphanedFavorites(
+  favoriteKeys: Iterable<string>,
+  corpora: { projectmPaths?: Set<string>; butterchurnNames?: Set<string> },
+): string[] {
+  const { projectmPaths, butterchurnNames } = corpora;
+  const orphans: string[] = [];
+  for (const key of favoriteKeys) {
+    if (key.startsWith(PROJECTM_PREFIX)) {
+      // Evaluate only against a loaded (present + non-empty) projectM corpus.
+      if (projectmPaths && projectmPaths.size > 0 && !projectmPaths.has(key.slice(PROJECTM_PREFIX.length))) {
+        orphans.push(key);
+      }
+    } else if (key.startsWith(BUTTERCHURN_PREFIX)) {
+      if (butterchurnNames && butterchurnNames.size > 0 && !butterchurnNames.has(key.slice(BUTTERCHURN_PREFIX.length))) {
+        orphans.push(key);
+      }
+    }
+    // Unknown prefix → never flagged (no accidental deletion semantics).
+  }
+  return orphans;
+}


### PR DESCRIPTION
## Summary
- Promote **v1.9.0-beta.14** to production.
- Ships **explicit orphaned-favorite cleanup**.
- Production remains **v1.9.0-beta.13** until this PR is merged.

## Included

### 1. Orphaned favorite detection helper (PR #77)
- Adds safe **corpus-gated** orphan detection (`orphanedFavorites`).
- Evaluates projectM keys **only when a projectM corpus is present and non-empty**.
- Evaluates butterchurn keys **only when a butterchurn corpus is present and non-empty**.
- **Absent/empty corpora are not treated as authoritative.**
- **Unknown-prefix keys are not flagged.**
- Helper is **pure and non-mutating**.

### 2. Explicit cleanup UI (PR #78)
- Appears in PresetSearch **only when active-engine unavailable favorites exist**.
- **User-initiated only**; **requires confirmation**.
- Removes **only positively detected active-engine orphan keys** (recomputed at click time).
- **Inactive-engine favorites are not counted or removed. Valid favorites are not removed. Unknown-prefix favorites are not removed.**
- **No automatic cleanup** on app load or search open.
- Storage shape remains `{ v: 1, keys: [...] }` (new atomic `removeFavorites` bulk action).

### 3. Release metadata (PR #79)
- Version bumped to **1.9.0-beta.14** (`package.json`, `package-lock.json`).
- About string updated to `Vibrdrome Web v1.9.0-beta.14`.
- CHANGELOG updated with the `[1.9.0-beta.14]` entry.

## Behavior preserved
favorite identity/storage shape · preset switching · preset search · ★ Only · next/previous · random · auto-advance · HUD ★ · Shift+F · `?preset=` · rendering/crossfade/engine · projectM/WebGPU · butterchurn.

## Excluded
no cross-device sync · no backend · no automatic cleanup · no app-load cleanup · no rendering changes · no engine changes · no preset-bundle changes · no dependency changes · no workflow/Dockerfile changes · no projectM-rs changes · no `src/pmweb/*` changes.

## Validation
- **PR #77:** pure helper; 13 safety tests (cross-engine + load-race covered).
- **PR #78:** 255 tests; manual projectM cleanup — invalid active-engine key removed only after confirmation; valid projectM key survived; butterchurn key not counted/removed in projectM session; Cancel deleted nothing; 0 console errors.
- **PR #79:** metadata-only; CI green; lockfile diff is only the two version fields.
- Promotion-PR checks run below and must pass before merge approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)