### PR TITLE
Add visualizer favorites export/import with union merge

### DIFF
--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -6,6 +6,7 @@ import { usePlayerStore } from '../stores/playerStore';
 import { useEQStore } from '../stores/eqStore';
 import { isValidHex } from '../utils/color';
 import { exportSettings, importSettings } from '../utils/settingsIO';
+import { exportFavorites, importFavoritesMerge } from '../utils/favoritesIO';
 import { Header } from '../components/common';
 import ThemePicker from '../components/settings/ThemePicker';
 
@@ -637,6 +638,37 @@ export default function SettingsScreen() {
                   className="rounded-lg border border-border px-4 py-2 text-sm text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary"
                 >
                   Import Settings
+                </button>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2 border-t border-border pt-3">
+                <button
+                  onClick={() => exportFavorites()}
+                  className="rounded-lg border border-border px-4 py-2 text-sm text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary"
+                >
+                  Export visualizer favorites
+                </button>
+                <button
+                  onClick={() => {
+                    const input = document.createElement('input');
+                    input.type = 'file';
+                    input.accept = '.json';
+                    input.onchange = async () => {
+                      const file = input.files?.[0];
+                      if (!file) return;
+                      try {
+                        const result = await importFavoritesMerge(file);
+                        alert(
+                          `Imported favorites: added ${result.added}, ${result.alreadyPresent} already present.`,
+                        );
+                      } catch {
+                        alert('Could not import favorites. Choose a valid Vibrdrome favorites export.');
+                      }
+                    };
+                    input.click();
+                  }}
+                  className="rounded-lg border border-border px-4 py-2 text-sm text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary"
+                >
+                  Import visualizer favorites
                 </button>
               </div>
             </div>

--- a/src/stores/presetFavoritesStore.test.ts
+++ b/src/stores/presetFavoritesStore.test.ts
@@ -125,4 +125,52 @@ describe('presetFavoritesStore', () => {
       expect([...usePresetFavoritesStore.getState().favoriteKeys]).toEqual(['projectm:b']);
     });
   });
+
+  describe('addFavorites (bulk union)', () => {
+    const seed = (keys: string[]) => {
+      const s = usePresetFavoritesStore.getState();
+      keys.forEach((k) => s.addFavorite(k));
+    };
+
+    it('adds only the missing keys and leaves existing keys intact', () => {
+      seed(['projectm:a', 'butterchurn:x']);
+      usePresetFavoritesStore.getState().addFavorites(['projectm:a', 'projectm:b', 'butterchurn:y']);
+      expect([...usePresetFavoritesStore.getState().favoriteKeys].sort()).toEqual([
+        'butterchurn:x',
+        'butterchurn:y',
+        'projectm:a',
+        'projectm:b',
+      ]);
+    });
+
+    it('is a no-op for an empty iterable (state ref unchanged → no set())', () => {
+      seed(['projectm:a']);
+      const before = usePresetFavoritesStore.getState().favoriteKeys;
+      usePresetFavoritesStore.getState().addFavorites([]);
+      expect(usePresetFavoritesStore.getState().favoriteKeys).toBe(before);
+    });
+
+    it('is a no-op when all keys already exist (no churn)', () => {
+      seed(['projectm:a', 'projectm:b']);
+      const before = usePresetFavoritesStore.getState().favoriteKeys;
+      usePresetFavoritesStore.getState().addFavorites(['projectm:a', 'projectm:b']);
+      expect(usePresetFavoritesStore.getState().favoriteKeys).toBe(before);
+    });
+
+    it('persists once, round-tripping the union in the versioned shape', () => {
+      seed(['projectm:a']);
+      usePresetFavoritesStore.getState().addFavorites(['butterchurn:x']);
+      const raw = localStorage.getItem(STORAGE_KEY);
+      const parsed = JSON.parse(raw!);
+      expect(parsed.v).toBe(1);
+      expect([...parsed.keys].sort()).toEqual(['butterchurn:x', 'projectm:a']);
+      expect([...loadFavorites()].sort()).toEqual(['butterchurn:x', 'projectm:a']);
+    });
+
+    it('accepts a Set as input', () => {
+      seed(['projectm:a']);
+      usePresetFavoritesStore.getState().addFavorites(new Set(['projectm:b']));
+      expect([...usePresetFavoritesStore.getState().favoriteKeys].sort()).toEqual(['projectm:a', 'projectm:b']);
+    });
+  });
 });

--- a/src/stores/presetFavoritesStore.ts
+++ b/src/stores/presetFavoritesStore.ts
@@ -36,6 +36,7 @@ interface PresetFavoritesState {
   favoriteKeys: Set<string>;
   isFavorite: (key: string) => boolean;
   addFavorite: (key: string) => void;
+  addFavorites: (keys: Iterable<string>) => void;
   removeFavorite: (key: string) => void;
   removeFavorites: (keys: Iterable<string>) => void;
   toggleFavorite: (key: string) => void;
@@ -48,6 +49,21 @@ export const usePresetFavoritesStore = create<PresetFavoritesState>((set, get) =
     if (get().favoriteKeys.has(key)) return;
     const next = new Set(get().favoriteKeys);
     next.add(key);
+    persist(next);
+    set({ favoriteKeys: next });
+  },
+  // Atomic bulk union (one persist + one state update). No-op if every key is
+  // already present — used by favorites import (union merge, never removes).
+  addFavorites: (keys) => {
+    const next = new Set(get().favoriteKeys);
+    let changed = false;
+    for (const key of keys) {
+      if (!next.has(key)) {
+        next.add(key);
+        changed = true;
+      }
+    }
+    if (!changed) return;
     persist(next);
     set({ favoriteKeys: next });
   },

--- a/src/utils/favoritesIO.test.ts
+++ b/src/utils/favoritesIO.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { buildFavoritesExport, mergeFavoritesFromText } from './favoritesIO';
+import { usePresetFavoritesStore } from '../stores/presetFavoritesStore';
+
+// Deterministic in-memory localStorage (the test env's built-in one is partial),
+// matching the presetFavoritesStore test harness.
+beforeEach(() => {
+  const store: Record<string, string> = {};
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => {
+      store[k] = String(v);
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) delete store[k];
+    },
+  });
+  usePresetFavoritesStore.setState({ favoriteKeys: new Set() });
+});
+afterEach(() => vi.unstubAllGlobals());
+
+const seed = (keys: string[]) => usePresetFavoritesStore.setState({ favoriteKeys: new Set(keys) });
+const currentKeys = () => [...usePresetFavoritesStore.getState().favoriteKeys].sort();
+const fileFor = (keys: unknown[], version: unknown = 1) =>
+  JSON.stringify({ version, exportedAt: '2026-06-21T00:00:00.000Z', favorites: { v: 1, keys } });
+
+describe('favoritesIO export', () => {
+  it('creates a versioned payload with the current favorite keys', () => {
+    seed(['projectm:a', 'butterchurn:b']);
+    const out = buildFavoritesExport(new Date('2026-06-21T12:00:00.000Z'));
+    expect(out.version).toBe(1);
+    expect(out.exportedAt).toBe('2026-06-21T12:00:00.000Z');
+    expect(out.favorites.v).toBe(1);
+    expect([...out.favorites.keys].sort()).toEqual(['butterchurn:b', 'projectm:a']);
+  });
+
+  it('excludes credentials / server / other settings (only favorites are present)', () => {
+    seed(['projectm:a']);
+    const out = buildFavoritesExport();
+    const json = JSON.stringify(out);
+    // Only the top-level keys version/exportedAt/favorites exist.
+    expect(Object.keys(out).sort()).toEqual(['exportedAt', 'favorites', 'version']);
+    // No credential/server fields leak in.
+    for (const forbidden of ['username', 'password', 'url', 'vibrdrome_servers', 'vibrdrome_active_server', 'server']) {
+      expect(json).not.toContain(forbidden);
+    }
+  });
+});
+
+describe('favoritesIO import (union merge)', () => {
+  it('adds new keys and reports the added count', () => {
+    seed([]);
+    const r = mergeFavoritesFromText(fileFor(['projectm:a', 'butterchurn:b']));
+    expect(r).toEqual({ added: 2, alreadyPresent: 0, ignoredInvalid: 0 });
+    expect(currentKeys()).toEqual(['butterchurn:b', 'projectm:a']);
+  });
+
+  it('keeps existing keys and only adds the missing ones (lossless union)', () => {
+    seed(['projectm:keep', 'butterchurn:keep']);
+    const r = mergeFavoritesFromText(fileFor(['projectm:keep', 'projectm:new']));
+    expect(r).toEqual({ added: 1, alreadyPresent: 1, ignoredInvalid: 0 });
+    expect(currentKeys()).toEqual(['butterchurn:keep', 'projectm:keep', 'projectm:new']);
+  });
+
+  it('importing a strict subset removes nothing', () => {
+    seed(['projectm:a', 'projectm:b', 'butterchurn:c']);
+    const r = mergeFavoritesFromText(fileFor(['projectm:a']));
+    expect(r).toEqual({ added: 0, alreadyPresent: 1, ignoredInvalid: 0 });
+    expect(currentKeys()).toEqual(['butterchurn:c', 'projectm:a', 'projectm:b']);
+  });
+
+  it('is idempotent for duplicate keys within the file', () => {
+    seed([]);
+    const r = mergeFavoritesFromText(fileFor(['projectm:a', 'projectm:a', 'projectm:a']));
+    expect(r.added).toBe(1);
+    expect(currentKeys()).toEqual(['projectm:a']);
+  });
+
+  it('filters non-string keys and counts them as ignoredInvalid', () => {
+    seed([]);
+    const r = mergeFavoritesFromText(fileFor(['projectm:a', 1, null, { x: 1 }, 'butterchurn:b']));
+    expect(r.added).toBe(2);
+    expect(r.ignoredInvalid).toBe(3);
+    expect(currentKeys()).toEqual(['butterchurn:b', 'projectm:a']);
+  });
+
+  it('a fully-present import is a no-op (no removals, nothing added)', () => {
+    seed(['projectm:a', 'butterchurn:b']);
+    const r = mergeFavoritesFromText(fileFor(['projectm:a', 'butterchurn:b']));
+    expect(r).toEqual({ added: 0, alreadyPresent: 2, ignoredInvalid: 0 });
+    expect(currentKeys()).toEqual(['butterchurn:b', 'projectm:a']);
+  });
+
+  // --- safe failure: never mutate on bad input ---
+
+  it('throws on malformed JSON and leaves favorites unchanged', () => {
+    seed(['projectm:keep']);
+    expect(() => mergeFavoritesFromText('not json {{{')).toThrow();
+    expect(currentKeys()).toEqual(['projectm:keep']);
+  });
+
+  it('throws on an unsupported version and leaves favorites unchanged', () => {
+    seed(['projectm:keep']);
+    expect(() => mergeFavoritesFromText(fileFor(['projectm:new'], 2))).toThrow();
+    expect(currentKeys()).toEqual(['projectm:keep']);
+  });
+
+  it('throws when the favorites payload is missing/invalid and leaves favorites unchanged', () => {
+    seed(['projectm:keep']);
+    expect(() => mergeFavoritesFromText(JSON.stringify({ version: 1, exportedAt: 'x' }))).toThrow();
+    expect(() => mergeFavoritesFromText(JSON.stringify({ version: 1, favorites: { v: 1, keys: 'oops' } }))).toThrow();
+    expect(() => mergeFavoritesFromText('null')).toThrow();
+    expect(currentKeys()).toEqual(['projectm:keep']);
+  });
+
+  it('round-trips an export back through import without loss', () => {
+    seed(['projectm:a', 'butterchurn:b', 'projectm:c']);
+    const exported = JSON.stringify(buildFavoritesExport());
+    usePresetFavoritesStore.setState({ favoriteKeys: new Set(['projectm:c', 'butterchurn:d']) });
+    const r = mergeFavoritesFromText(exported);
+    expect(r.added).toBe(2); // a + b are new; c already present
+    expect(currentKeys()).toEqual(['butterchurn:b', 'butterchurn:d', 'projectm:a', 'projectm:c']);
+  });
+});

--- a/src/utils/favoritesIO.ts
+++ b/src/utils/favoritesIO.ts
@@ -1,0 +1,79 @@
+// Favorites-only export / import for moving visualizer favorites between
+// devices WITHOUT a backend. Import is a lossless UNION merge — it adds the
+// file's keys to the local set and never removes or replaces existing ones.
+//
+// The payload deliberately contains ONLY the favorite keys (which are preset
+// paths/names — no PII): no server URL, username, password, or other settings.
+import { usePresetFavoritesStore } from '../stores/presetFavoritesStore';
+
+/** On-disk export shape (the inner `favorites` blob matches the store's). */
+export interface FavoritesExport {
+  version: 1;
+  exportedAt: string;
+  favorites: { v: 1; keys: string[] };
+}
+
+export interface FavoritesImportResult {
+  added: number;
+  alreadyPresent: number;
+  ignoredInvalid: number;
+}
+
+/** Build the export payload from the current favorites (no credentials). */
+export function buildFavoritesExport(now: Date = new Date()): FavoritesExport {
+  const keys = [...usePresetFavoritesStore.getState().favoriteKeys];
+  return { version: 1, exportedAt: now.toISOString(), favorites: { v: 1, keys } };
+}
+
+/** Download the current visualizer favorites as a versioned JSON file. */
+export function exportFavorites(now: Date = new Date()): void {
+  const data = buildFavoritesExport(now);
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `vibrdrome-visualizer-favorites-${now.toISOString().slice(0, 10)}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Parse a favorites-export string and UNION its keys into the store. Validation
+ * throws BEFORE any mutation, so a malformed/unsupported file leaves local
+ * favorites unchanged. Non-string keys are ignored; duplicates are idempotent.
+ */
+export function mergeFavoritesFromText(text: string): FavoritesImportResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error('Invalid favorites file');
+  }
+  if (!parsed || typeof parsed !== 'object') throw new Error('Invalid favorites file');
+  const obj = parsed as { version?: unknown; favorites?: unknown };
+  if (obj.version !== 1) throw new Error('Unsupported favorites file version');
+  const fav = obj.favorites as { keys?: unknown } | undefined;
+  if (!fav || typeof fav !== 'object' || !Array.isArray(fav.keys)) {
+    throw new Error('Invalid favorites file');
+  }
+
+  const rawKeys = fav.keys as unknown[];
+  const validKeys = rawKeys.filter((k): k is string => typeof k === 'string');
+  const ignoredInvalid = rawKeys.length - validKeys.length;
+
+  const uniqueKeys = [...new Set(validKeys)];
+  const existing = usePresetFavoritesStore.getState().favoriteKeys;
+  const toAdd = uniqueKeys.filter((k) => !existing.has(k));
+  const alreadyPresent = uniqueKeys.length - toAdd.length;
+
+  // Union merge (no-op when toAdd is empty). Never removes existing favorites.
+  usePresetFavoritesStore.getState().addFavorites(toAdd);
+
+  return { added: toAdd.length, alreadyPresent, ignoredInvalid };
+}
+
+/** Read a favorites-export File and union-merge it into the store. */
+export async function importFavoritesMerge(file: File): Promise<FavoritesImportResult> {
+  const text = await file.text();
+  return mergeFavoritesFromText(text);
+}


### PR DESCRIPTION
## Summary
Adds a safe, manual, **favorites-scoped** export/import so users can move visualizer favorites across devices **without a backend** — import is a lossless **union merge**.

- Adds favorites-scoped **export/import** (Settings buttons: *Export visualizer favorites* / *Import visualizer favorites*).
- Export file contains **only visualizer favorite keys**.
- Export **excludes server URL, username, password, and all other settings**.
- Import **union-merges** favorites — **never removes** existing favorites; **never replaces** the full set.
- Invalid/unsupported files **fail safely with no mutation** (validation throws before any write).
- Adds atomic **`addFavorites(keys)`** bulk store action (mirror of `removeFavorites`).
- Existing whole-settings `settingsIO.ts` export/import is **unchanged**.

## Export payload
```json
{ "version": 1, "exportedAt": "<iso>", "favorites": { "v": 1, "keys": ["projectm:…","butterchurn:…"] } }
```

## Out of scope / unchanged
- No backend. No Cloudflare Worker/KV/D1/R2. No Subsonic/Navidrome metadata or playlist abuse. No automatic/background sync. No account system. No credential exposure.
- No favorite key-identity change. No favorite storage-shape change (`{ v: 1, keys: [...] }`).
- No dependency / workflow / Dockerfile / release-metadata changes. No projectM-rs / `src/pmweb/*` / bundle / rendering changes.
- Visualizer runtime untouched: search, ★ Only, next/previous, random, auto-advance, HUD ★, Shift+F, orphan cleanup, `?preset=`.

## Files changed (5)
- `src/utils/favoritesIO.ts` (+ `.test.ts`)
- `src/stores/presetFavoritesStore.ts` (+ `.test.ts`) — `addFavorites`
- `src/screens/SettingsScreen.tsx` — export/import buttons

## Test plan
- `npm run lint` — clean
- `npm run test:run` — 272/272 (+17: 12 favoritesIO, 5 store)
- `npm run build` — succeeds
- `npm run test:smoke` — 0 console errors
- Manual (real Chrome, two contexts = two devices): A's export has only favorites (no credentials); importing A's file into B keeps B's own favorite **and** gains A's (added 2, 1 already present); a malformed file leaves B's favorites unchanged with an error message; 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)