### PR TITLE
Prepare v1.9.0-beta.15 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.15] - 2026-06-22
+
+### Added
+- **Visualizer favorites export / import** — move your visualizer favorites between devices via a JSON file.
+
+### Notes
+- Export is favorites-scoped and writes a JSON file containing **only visualizer favorite keys**.
+- Export **excludes server URL, username, password, `vibrdrome_servers`, and all other settings**.
+- Import **union-merges** favorites and **never removes or replaces** existing favorites.
+- Invalid or unsupported imports **fail safely without changing local favorites**.
+- The existing whole-settings export/import remains unchanged.
+- Favorite key identity and storage shape remain unchanged: `{ v: 1, keys: [...] }`.
+- No backend, account system, automatic sync, Cloudflare Worker/KV/D1/R2, or Subsonic/Navidrome metadata/playlist sync.
+- No rendering, engine, crossfade, preset-bundle, dependency, workflow, Dockerfile, projectM-rs, or `src/pmweb/*` changes.
+- Deferred: true backend cross-device sync remains intentionally deferred.
+
 ## [1.9.0-beta.14] - 2026-06-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.14",
+  "version": "1.9.0-beta.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.14",
+      "version": "1.9.0-beta.15",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.14",
+  "version": "1.9.0-beta.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -680,7 +680,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.14</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.15</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">


### PR DESCRIPTION
## Summary

Release metadata for **v1.9.0-beta.15**, shipping the client-only visualizer favorites export/import staged on `develop` — bundles **PR #81 only**.

- **Version bump** `1.9.0-beta.14` → `1.9.0-beta.15` (`package.json`, `package-lock.json` root + `packages[""]`, `SettingsScreen` About string).
- **CHANGELOG** entry for visualizer favorites export/import with union merge.
- **No dependency changes** (lockfile touches only the two version fields).
- **No workflow / Dockerfile changes.**
- **No engine / projectM changes. No backend sync. No automatic sync.**
- **No release/deploy yet** — metadata only.

## Files changed (4)
- `package.json`
- `package-lock.json`
- `src/screens/SettingsScreen.tsx`
- `CHANGELOG.md`

## CHANGELOG [1.9.0-beta.15]
Added: visualizer favorites export/import. Notes: export is favorites-scoped (JSON with only favorite keys); excludes server URL, username, password, `vibrdrome_servers`, and all other settings; import union-merges and never removes/replaces existing favorites; invalid/unsupported imports fail safely without changing local favorites; existing whole-settings export/import unchanged; favorite key identity + storage shape unchanged `{ v: 1, keys: [...] }`; no backend/account/automatic sync/Cloudflare Worker-KV-D1-R2/Subsonic metadata-playlist sync; no rendering/engine/crossfade/preset-bundle/dependency/workflow/Dockerfile/projectM-rs/`src/pmweb/*` changes. Deferred: true backend cross-device sync.

## Test plan
- `npm run lint` — clean
- `npm run test:run` — 272/272
- `npm run build` — succeeds
- `npm run test:smoke` — 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)