### PR TITLE
Persist visualizer mode across reloads

### DIFF
--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -309,7 +309,9 @@ export default function VisualizerScreen() {
   const transportRadio = usePlayerStore((s) => s.radioMode);
   const transportVisible = visualizerShowTransport && (!!transportSong || !!transportRadio);
 
-  const [mode, setMode] = useState<'shader' | 'milkdrop'>('shader');
+  // Persisted across reloads (uiStore) so the engine choice survives a refresh.
+  const mode = useUIStore((s) => s.visualizerMode);
+  const setVisualizerMode = useUIStore((s) => s.setVisualizerMode);
   const [frozen, setFrozen] = useState(false);
   const [showFps, setShowFps] = useState(false);
   const [fps, setFps] = useState(0);
@@ -1231,7 +1233,7 @@ export default function VisualizerScreen() {
             <button
               onClick={(e) => {
                 e.stopPropagation();
-                setMode((m) => (m === 'shader' ? 'milkdrop' : 'shader'));
+                setVisualizerMode(mode === 'shader' ? 'milkdrop' : 'shader');
                 resetOverlayTimer();
               }}
               className="rounded-full bg-white/10 px-3 py-1.5 text-xs font-medium text-white/80 transition-colors hover:bg-white/20"

--- a/src/stores/uiStore.test.ts
+++ b/src/stores/uiStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useUIStore } from './uiStore';
 
 beforeEach(() => {
@@ -132,5 +132,62 @@ describe('uiStore', () => {
       useUIStore.getState().setVisualizerFavoritesOnly(false);
       expect(useUIStore.getState().visualizerFavoritesOnly).toBe(false);
     });
+  });
+});
+
+// visualizerMode persistence: the init reads localStorage at module-load time,
+// so the load/fallback cases re-import the module with a stubbed localStorage.
+describe('uiStore visualizerMode persistence', () => {
+  const MODE_KEY = 'vibrdrome_visualizer_mode';
+  const stub = (initial: Record<string, string> = {}) => {
+    const backing: Record<string, string> = { ...initial };
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => (k in backing ? backing[k] : null),
+      setItem: (k: string, v: string) => { backing[k] = String(v); },
+      removeItem: (k: string) => { delete backing[k]; },
+      clear: () => { for (const k of Object.keys(backing)) delete backing[k]; },
+    });
+    return backing;
+  };
+  const freshStore = async () => {
+    vi.resetModules();
+    return (await import('./uiStore')).useUIStore;
+  };
+  afterEach(() => { vi.unstubAllGlobals(); vi.resetModules(); });
+
+  it('defaults to shader when nothing is persisted', async () => {
+    stub({});
+    expect((await freshStore()).getState().visualizerMode).toBe('shader');
+  });
+
+  it('loads a persisted milkdrop value', async () => {
+    stub({ [MODE_KEY]: 'milkdrop' });
+    expect((await freshStore()).getState().visualizerMode).toBe('milkdrop');
+  });
+
+  it('loads a persisted shader value', async () => {
+    stub({ [MODE_KEY]: 'shader' });
+    expect((await freshStore()).getState().visualizerMode).toBe('shader');
+  });
+
+  it('falls back to shader for an invalid persisted value', async () => {
+    stub({ [MODE_KEY]: 'bogus-engine' });
+    expect((await freshStore()).getState().visualizerMode).toBe('shader');
+  });
+
+  it('setter persists milkdrop', async () => {
+    const backing = stub({});
+    const store = await freshStore();
+    store.getState().setVisualizerMode('milkdrop');
+    expect(store.getState().visualizerMode).toBe('milkdrop');
+    expect(backing[MODE_KEY]).toBe('milkdrop');
+  });
+
+  it('setter persists shader', async () => {
+    const backing = stub({ [MODE_KEY]: 'milkdrop' });
+    const store = await freshStore();
+    store.getState().setVisualizerMode('shader');
+    expect(store.getState().visualizerMode).toBe('shader');
+    expect(backing[MODE_KEY]).toBe('shader');
   });
 });

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -21,6 +21,7 @@ const VIS_TRANSITION_POLISH_KEY = 'vibrdrome_visualizer_transition_polish';
 const VIS_PARTICLES_KEY = 'vibrdrome_visualizer_particles';
 const VIS_PIN_CONTROLS_KEY = 'vibrdrome_visualizer_pin_controls';
 const VIS_PRESET_TRANSITION_KEY = 'vibrdrome_visualizer_preset_transition';
+const VIS_MODE_KEY = 'vibrdrome_visualizer_mode';
 const DEFAULT_ACCENT = '#8b5cf6';
 
 type Theme = 'system' | 'dark' | 'light' | 'apple' | 'apple-dark' | 'retro' | 'terminal' | 'midnight' | 'sunset';
@@ -83,6 +84,8 @@ interface UIState {
   setVisualizerPinControls: (value: boolean) => void;
   visualizerPresetTransition: 'hard-cut' | 'fade';
   setVisualizerPresetTransition: (value: 'hard-cut' | 'fade') => void;
+  visualizerMode: 'shader' | 'milkdrop';
+  setVisualizerMode: (value: 'shader' | 'milkdrop') => void;
 
   castConnected: boolean;
   setCastConnected: (connected: boolean) => void;
@@ -281,6 +284,17 @@ export const useUIStore = create<UIState>((set) => ({
   setVisualizerPresetTransition: (value) => {
     try { localStorage.setItem(VIS_PRESET_TRANSITION_KEY, value); } catch { /* ignore */ }
     set({ visualizerPresetTransition: value });
+  },
+
+  // Last-selected visualizer engine: 'shader' (default) or 'milkdrop'. Persisted
+  // so the choice survives reloads; only those two values are accepted.
+  visualizerMode: (() => {
+    try { return localStorage.getItem(VIS_MODE_KEY) === 'milkdrop' ? 'milkdrop' : 'shader'; }
+    catch { return 'shader'; }
+  })(),
+  setVisualizerMode: (value) => {
+    try { localStorage.setItem(VIS_MODE_KEY, value); } catch { /* ignore */ }
+    set({ visualizerMode: value });
   },
 
   castConnected: false,


### PR DESCRIPTION
## Summary
Persists the user's selected visualizer engine (shader ↔ Milkdrop) so it survives a reload, instead of resetting to shader every visit.

- Adds persisted **`visualizerMode`** state to `uiStore` (`shader` | `milkdrop`), stored at **`vibrdrome_visualizer_mode`**.
- **First-run default stays `shader`.**
- Restores the **last selected mode on reload**.
- **Invalid/missing persisted values fall back to `shader`.**
- Replaces `VisualizerScreen`'s local `useState('shader')` with store-backed mode; the toggle calls `setVisualizerMode`.
- **No WebGPU auto-selection. No default-mode product change.**

## Out of scope / unchanged
- No auth/password/security changes. No localStorage encryption.
- No dependency / workflow / Dockerfile / release-metadata changes. No projectM-rs / `src/pmweb/*` / bundle changes.
- No rendering/crossfade/engine changes. Crossfade settings/duration, favorites, search, cleanup, export/import all unchanged (they read the same `mode` variable + existing settings).

## Files changed (3)
- `src/stores/uiStore.ts` (+ `.test.ts`) — `visualizerMode` + `setVisualizerMode` + `VIS_MODE_KEY`
- `src/screens/VisualizerScreen.tsx` — local mode state → store-backed

## Test plan
- `npm run lint` — clean
- `npm run test:run` — 278/278 (+6 uiStore tests)
- `npm run build` — succeeds
- `npm run test:smoke` — 0 console errors
- Manual (real Chrome): fresh→shader (no key); toggle→Milkdrop persists `milkdrop`; reload restores Milkdrop; toggle→Shader persists `shader`; reload restores shader; invalid value `bogus-engine`→shader; 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)