### PR TITLE
Prepare v1.9.0-beta.16 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.16] - 2026-06-22
+
+### Added
+- **Visualizer mode now persists across reloads** — your `shader` / `milkdrop` choice is remembered.
+
+### Notes
+- The selected `shader` or `milkdrop` mode is saved to `vibrdrome_visualizer_mode`.
+- First-run default remains `shader`.
+- Invalid persisted values fall back to `shader`.
+- No WebGPU-based auto-selection.
+- No default-mode product change.
+- No auth/password/token/encryption changes.
+- No rendering, engine, crossfade, preset-bundle, dependency, workflow, Dockerfile, projectM-rs, or `src/pmweb/*` changes.
+- Deferred: password-to-token auth storage hardening remains a separate future track.
+
 ## [1.9.0-beta.15] - 2026-06-22
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.15",
+  "version": "1.9.0-beta.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.15",
+      "version": "1.9.0-beta.16",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.15",
+  "version": "1.9.0-beta.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -680,7 +680,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.15</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.16</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">


### PR DESCRIPTION
## Summary

Release metadata for **v1.9.0-beta.16**, shipping the app-only visualizer mode persistence staged on `develop` — bundles **PR #84 only**.

- **Version bump** `1.9.0-beta.15` → `1.9.0-beta.16` (`package.json`, `package-lock.json` root + `packages[""]`, `SettingsScreen` About string).
- **CHANGELOG** entry for visualizer mode persistence.
- **No dependency changes** (lockfile touches only the two version fields).
- **No workflow / Dockerfile changes.**
- **No engine / projectM changes. No auth / password / token / encryption changes. No default-mode product change.**
- **No release/deploy yet** — metadata only.

## Files changed (4)
- `package.json`
- `package-lock.json`
- `src/screens/SettingsScreen.tsx`
- `CHANGELOG.md`

## CHANGELOG [1.9.0-beta.16]
Added: visualizer mode now persists across reloads. Notes: selected `shader`/`milkdrop` saved to `vibrdrome_visualizer_mode`; first-run default remains `shader`; invalid persisted values fall back to `shader`; no WebGPU auto-selection; no default-mode product change; no auth/password/token/encryption changes; no rendering/engine/crossfade/preset-bundle/dependency/workflow/Dockerfile/projectM-rs/`src/pmweb/*` changes. Deferred: password-to-token auth storage hardening remains a separate future track.

## Test plan
- `npm run lint` — clean
- `npm run test:run` — 278/278
- `npm run build` — succeeds
- `npm run test:smoke` — 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)