### PR TITLE
Release v1.9.0-beta.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Vibrdrome Web are documented here.
 
+## [1.9.0-beta.16] - 2026-06-22
+
+### Added
+- **Visualizer mode now persists across reloads** — your `shader` / `milkdrop` choice is remembered.
+
+### Notes
+- The selected `shader` or `milkdrop` mode is saved to `vibrdrome_visualizer_mode`.
+- First-run default remains `shader`.
+- Invalid persisted values fall back to `shader`.
+- No WebGPU-based auto-selection.
+- No default-mode product change.
+- No auth/password/token/encryption changes.
+- No rendering, engine, crossfade, preset-bundle, dependency, workflow, Dockerfile, projectM-rs, or `src/pmweb/*` changes.
+- Deferred: password-to-token auth storage hardening remains a separate future track.
+
 ## [1.9.0-beta.15] - 2026-06-22
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibrdrome-web",
-  "version": "1.9.0-beta.15",
+  "version": "1.9.0-beta.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibrdrome-web",
-      "version": "1.9.0-beta.15",
+      "version": "1.9.0-beta.16",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "butterchurn": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibrdrome-web",
   "private": true,
-  "version": "1.9.0-beta.15",
+  "version": "1.9.0-beta.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -680,7 +680,7 @@ export default function SettingsScreen() {
               About
             </h2>
             <div className="space-y-3 rounded-lg bg-bg-secondary p-4">
-              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.15</p>
+              <p className="text-sm text-text-muted">Vibrdrome Web v1.9.0-beta.16</p>
               <div className="border-t border-border pt-3">
                 <p className="text-xs font-medium text-text-secondary">Open-source components</p>
                 <p className="mt-1 text-xs text-text-muted">

--- a/src/screens/VisualizerScreen.tsx
+++ b/src/screens/VisualizerScreen.tsx
@@ -309,7 +309,9 @@ export default function VisualizerScreen() {
   const transportRadio = usePlayerStore((s) => s.radioMode);
   const transportVisible = visualizerShowTransport && (!!transportSong || !!transportRadio);
 
-  const [mode, setMode] = useState<'shader' | 'milkdrop'>('shader');
+  // Persisted across reloads (uiStore) so the engine choice survives a refresh.
+  const mode = useUIStore((s) => s.visualizerMode);
+  const setVisualizerMode = useUIStore((s) => s.setVisualizerMode);
   const [frozen, setFrozen] = useState(false);
   const [showFps, setShowFps] = useState(false);
   const [fps, setFps] = useState(0);
@@ -1231,7 +1233,7 @@ export default function VisualizerScreen() {
             <button
               onClick={(e) => {
                 e.stopPropagation();
-                setMode((m) => (m === 'shader' ? 'milkdrop' : 'shader'));
+                setVisualizerMode(mode === 'shader' ? 'milkdrop' : 'shader');
                 resetOverlayTimer();
               }}
               className="rounded-full bg-white/10 px-3 py-1.5 text-xs font-medium text-white/80 transition-colors hover:bg-white/20"

--- a/src/stores/uiStore.test.ts
+++ b/src/stores/uiStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useUIStore } from './uiStore';
 
 beforeEach(() => {
@@ -132,5 +132,62 @@ describe('uiStore', () => {
       useUIStore.getState().setVisualizerFavoritesOnly(false);
       expect(useUIStore.getState().visualizerFavoritesOnly).toBe(false);
     });
+  });
+});
+
+// visualizerMode persistence: the init reads localStorage at module-load time,
+// so the load/fallback cases re-import the module with a stubbed localStorage.
+describe('uiStore visualizerMode persistence', () => {
+  const MODE_KEY = 'vibrdrome_visualizer_mode';
+  const stub = (initial: Record<string, string> = {}) => {
+    const backing: Record<string, string> = { ...initial };
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => (k in backing ? backing[k] : null),
+      setItem: (k: string, v: string) => { backing[k] = String(v); },
+      removeItem: (k: string) => { delete backing[k]; },
+      clear: () => { for (const k of Object.keys(backing)) delete backing[k]; },
+    });
+    return backing;
+  };
+  const freshStore = async () => {
+    vi.resetModules();
+    return (await import('./uiStore')).useUIStore;
+  };
+  afterEach(() => { vi.unstubAllGlobals(); vi.resetModules(); });
+
+  it('defaults to shader when nothing is persisted', async () => {
+    stub({});
+    expect((await freshStore()).getState().visualizerMode).toBe('shader');
+  });
+
+  it('loads a persisted milkdrop value', async () => {
+    stub({ [MODE_KEY]: 'milkdrop' });
+    expect((await freshStore()).getState().visualizerMode).toBe('milkdrop');
+  });
+
+  it('loads a persisted shader value', async () => {
+    stub({ [MODE_KEY]: 'shader' });
+    expect((await freshStore()).getState().visualizerMode).toBe('shader');
+  });
+
+  it('falls back to shader for an invalid persisted value', async () => {
+    stub({ [MODE_KEY]: 'bogus-engine' });
+    expect((await freshStore()).getState().visualizerMode).toBe('shader');
+  });
+
+  it('setter persists milkdrop', async () => {
+    const backing = stub({});
+    const store = await freshStore();
+    store.getState().setVisualizerMode('milkdrop');
+    expect(store.getState().visualizerMode).toBe('milkdrop');
+    expect(backing[MODE_KEY]).toBe('milkdrop');
+  });
+
+  it('setter persists shader', async () => {
+    const backing = stub({ [MODE_KEY]: 'milkdrop' });
+    const store = await freshStore();
+    store.getState().setVisualizerMode('shader');
+    expect(store.getState().visualizerMode).toBe('shader');
+    expect(backing[MODE_KEY]).toBe('shader');
   });
 });

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -21,6 +21,7 @@ const VIS_TRANSITION_POLISH_KEY = 'vibrdrome_visualizer_transition_polish';
 const VIS_PARTICLES_KEY = 'vibrdrome_visualizer_particles';
 const VIS_PIN_CONTROLS_KEY = 'vibrdrome_visualizer_pin_controls';
 const VIS_PRESET_TRANSITION_KEY = 'vibrdrome_visualizer_preset_transition';
+const VIS_MODE_KEY = 'vibrdrome_visualizer_mode';
 const DEFAULT_ACCENT = '#8b5cf6';
 
 type Theme = 'system' | 'dark' | 'light' | 'apple' | 'apple-dark' | 'retro' | 'terminal' | 'midnight' | 'sunset';
@@ -83,6 +84,8 @@ interface UIState {
   setVisualizerPinControls: (value: boolean) => void;
   visualizerPresetTransition: 'hard-cut' | 'fade';
   setVisualizerPresetTransition: (value: 'hard-cut' | 'fade') => void;
+  visualizerMode: 'shader' | 'milkdrop';
+  setVisualizerMode: (value: 'shader' | 'milkdrop') => void;
 
   castConnected: boolean;
   setCastConnected: (connected: boolean) => void;
@@ -281,6 +284,17 @@ export const useUIStore = create<UIState>((set) => ({
   setVisualizerPresetTransition: (value) => {
     try { localStorage.setItem(VIS_PRESET_TRANSITION_KEY, value); } catch { /* ignore */ }
     set({ visualizerPresetTransition: value });
+  },
+
+  // Last-selected visualizer engine: 'shader' (default) or 'milkdrop'. Persisted
+  // so the choice survives reloads; only those two values are accepted.
+  visualizerMode: (() => {
+    try { return localStorage.getItem(VIS_MODE_KEY) === 'milkdrop' ? 'milkdrop' : 'shader'; }
+    catch { return 'shader'; }
+  })(),
+  setVisualizerMode: (value) => {
+    try { localStorage.setItem(VIS_MODE_KEY, value); } catch { /* ignore */ }
+    set({ visualizerMode: value });
   },
 
   castConnected: false,


### PR DESCRIPTION
## Summary
- Promote **v1.9.0-beta.16** to production.
- Ships **visualizer mode persistence**.
- Production remains **v1.9.0-beta.15** until this PR is merged.

## Included

### 1. Visualizer mode persistence (PR #84)
- Persists the selected visualizer mode across reloads.
- Saves `shader` / `milkdrop` to `vibrdrome_visualizer_mode`.
- **First-run default remains `shader`.**
- **Invalid persisted values fall back to `shader`.**
- **No WebGPU auto-selection. No default-mode product change.**

### 2. Release metadata (PR #85)
- Version bumped to **1.9.0-beta.16** (`package.json`, `package-lock.json`).
- About string updated to `Vibrdrome Web v1.9.0-beta.16`.
- CHANGELOG updated with the `[1.9.0-beta.16]` entry.

## Behavior preserved
first-run shader default · local visualizer favorites · preset search · ★ Only · next/previous · random/auto-advance · HUD ★ · Shift+F · orphan cleanup · favorites export/import · `?preset=` · crossfade hard-cut/fade · rendering/crossfade/engine · projectM/WebGPU · butterchurn · authentication.

## Excluded
no auth/password/token/encryption changes · no default-mode change · no WebGPU auto-selection · no backend · no dependency changes · no workflow/Dockerfile changes · no projectM-rs changes · no `src/pmweb/*` changes · no rendering/crossfade/engine changes.

## Validation
- **PR #84:** 278 tests; default shader; persisted milkdrop restores as milkdrop; persisted shader restores as shader; invalid value → shader; manual reload validation in real Chrome; smoke 0 console errors.
- **PR #85:** metadata-only; CI green; lockfile diff is only the two version fields.
- Promotion-PR checks run below and must pass before merge approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)